### PR TITLE
Changed CMake minimal version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 project(PatternLanguage)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 project(pattern_language_example)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 project(libpl)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
The minimal CMake version is currently 3.21, but the project can be compiled using older versions, such as 3.16

This should (kind of) fix this issue : https://github.com/WerWolv/ImHex/issues/506