### PR TITLE
pattern: reintroduce static array color override

### DIFF
--- a/lib/include/pl/patterns/pattern_array_static.hpp
+++ b/lib/include/pl/patterns/pattern_array_static.hpp
@@ -61,6 +61,7 @@ namespace pl {
         void setColor(u32 color) override {
             Pattern::setColor(color);
             this->m_template->setColor(color);
+            this->m_highlightTemplate->setColor(color);
         }
 
         [[nodiscard]] std::string getFormattedName() const override {


### PR DESCRIPTION
It was left out while refactoring.
No biggie.