### PR TITLE
Pointer fixes & feature

### DIFF
--- a/lib/include/pl/ast/ast_node_pointer_variable_decl.hpp
+++ b/lib/include/pl/ast/ast_node_pointer_variable_decl.hpp
@@ -10,7 +10,7 @@ namespace pl {
     class ASTNodePointerVariableDecl : public ASTNode,
                                        public Attributable {
     public:
-        ASTNodePointerVariableDecl(std::string name, std::shared_ptr<ASTNodeTypeDecl> type, std::shared_ptr<ASTNodeTypeDecl> sizeType, std::unique_ptr<ASTNode> &&placementOffset = nullptr)
+        ASTNodePointerVariableDecl(std::string name, std::shared_ptr<ASTNode> type, std::shared_ptr<ASTNodeTypeDecl> sizeType, std::unique_ptr<ASTNode> &&placementOffset = nullptr)
             : ASTNode(), m_name(std::move(name)), m_type(std::move(type)), m_sizeType(std::move(sizeType)), m_placementOffset(std::move(placementOffset)) { }
 
         ASTNodePointerVariableDecl(const ASTNodePointerVariableDecl &other) : ASTNode(other), Attributable(other) {
@@ -29,7 +29,7 @@ namespace pl {
         }
 
         [[nodiscard]] const std::string &getName() const { return this->m_name; }
-        [[nodiscard]] constexpr const std::shared_ptr<ASTNodeTypeDecl> &getType() const { return this->m_type; }
+        [[nodiscard]] constexpr const std::shared_ptr<ASTNode> &getType() const { return this->m_type; }
         [[nodiscard]] constexpr const std::shared_ptr<ASTNodeTypeDecl> &getSizeType() const { return this->m_sizeType; }
         [[nodiscard]] constexpr const std::unique_ptr<ASTNode> &getPlacementOffset() const { return this->m_placementOffset; }
 
@@ -87,7 +87,7 @@ namespace pl {
 
     private:
         std::string m_name;
-        std::shared_ptr<ASTNodeTypeDecl> m_type;
+        std::shared_ptr<ASTNode> m_type;
         std::shared_ptr<ASTNodeTypeDecl> m_sizeType;
         std::unique_ptr<ASTNode> m_placementOffset;
     };

--- a/lib/include/pl/parser.hpp
+++ b/lib/include/pl/parser.hpp
@@ -117,6 +117,7 @@ namespace pl {
         std::unique_ptr<ASTNode> parseMemberVariable(const std::shared_ptr<ASTNodeTypeDecl> &type);
         std::unique_ptr<ASTNode> parseMemberArrayVariable(const std::shared_ptr<ASTNodeTypeDecl> &type);
         std::unique_ptr<ASTNode> parseMemberPointerVariable(const std::shared_ptr<ASTNodeTypeDecl> &type);
+        std::unique_ptr<ASTNode> parseMemberPointerArrayVariable(const std::shared_ptr<ASTNodeTypeDecl> &type);
         std::unique_ptr<ASTNode> parseMember();
         std::shared_ptr<ASTNodeTypeDecl> parseStruct();
         std::shared_ptr<ASTNodeTypeDecl> parseUnion();
@@ -127,6 +128,7 @@ namespace pl {
         std::unique_ptr<ASTNode> parseVariablePlacement(const std::shared_ptr<ASTNodeTypeDecl> &type);
         std::unique_ptr<ASTNode> parseArrayVariablePlacement(const std::shared_ptr<ASTNodeTypeDecl> &type);
         std::unique_ptr<ASTNode> parsePointerVariablePlacement(const std::shared_ptr<ASTNodeTypeDecl> &type);
+        std::unique_ptr<ASTNode> parsePointerArrayVariablePlacement(const std::shared_ptr<ASTNodeTypeDecl> &type);
         std::unique_ptr<ASTNode> parsePlacement();
         std::vector<std::shared_ptr<ASTNode>> parseNamespace();
         std::vector<std::shared_ptr<ASTNode>> parseStatements();

--- a/lib/include/pl/patterns/pattern_pointer.hpp
+++ b/lib/include/pl/patterns/pattern_pointer.hpp
@@ -49,7 +49,9 @@ namespace pl {
         }
 
         [[nodiscard]] std::vector<std::pair<u64, Pattern*>> getChildren() override {
-            return this->m_pointedAt->getChildren();
+            auto children = this->m_pointedAt->getChildren();
+            children.emplace_back(this->getOffset(), this);
+            return children;
         }
 
         void setMemoryLocationType(PatternMemoryType type) override {
@@ -62,6 +64,7 @@ namespace pl {
             this->m_pointedAt = std::move(pattern);
             this->m_pointedAt->setVariableName(fmt::format("*({})", this->getVariableName()));
             this->m_pointedAt->setOffset(this->m_pointedAtAddress);
+            this->m_pointedAt->setColor(Pattern::getColor());
         }
 
         void setPointedAtAddress(u64 address) {
@@ -78,7 +81,9 @@ namespace pl {
 
         void setColor(u32 color) override {
             Pattern::setColor(color);
-            this->m_pointedAt->setColor(color);
+            if (this->m_pointedAt != nullptr) {
+                this->m_pointedAt->setColor(color);
+            }
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override {


### PR DESCRIPTION
A few updates.

- Fixed crash when setting color override attribute
- Pointer itself is catchable via getPattern (can set bg color in editor)
- Pointer can point to array
 
So instead of

```rust
struct Array {
  u32 data[10];
};

Array *arr : u32 @0;
```

can simply be

```rust
u32 *data[10] : u32 @0;
```

Can add unit test later :)