### PR TITLE
pattern: inlined array shows varname

### DIFF
--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -16,7 +16,7 @@ namespace pl {
     class Inlinable {
     public:
         [[nodiscard]] bool isInlined() const { return this->m_inlined; }
-        void setInlined(bool inlined) { this->m_inlined = inlined; }
+        virtual void setInlined(bool inlined) { this->m_inlined = inlined; }
 
     private:
         bool m_inlined = false;

--- a/lib/include/pl/patterns/pattern_array_dynamic.hpp
+++ b/lib/include/pl/patterns/pattern_array_dynamic.hpp
@@ -75,6 +75,25 @@ namespace pl {
                 fn(i, *this->m_entries[i]);
         }
 
+        void setInlined(bool isInlined) override {
+            Inlinable::setInlined(isInlined);
+            if (isInlined) {
+                for (auto &e : this->m_entries) {
+                    if (auto &varName = e->getVariableName(); !varName.empty() && varName.front() == '[') {
+                        e->setVariableName(this->getVariableName() + varName);
+                    }
+                }
+            } else {
+                for (auto &e : this->m_entries) {
+                    if (auto &varName = e->getVariableName(); !varName.empty()) {
+                        if (auto foundBracket = varName.find_last_of('['); foundBracket != varName.npos) {
+                            e->setVariableName(varName.substr(foundBracket));
+                        }
+                    }
+                }
+            }
+        }
+
         void setEntries(std::vector<std::shared_ptr<Pattern>> &&entries) {
             this->m_entries = std::move(entries);
 

--- a/lib/include/pl/patterns/pattern_array_static.hpp
+++ b/lib/include/pl/patterns/pattern_array_static.hpp
@@ -23,9 +23,18 @@ namespace pl {
             auto entry = std::shared_ptr(this->m_template->clone());
             for (u64 index = 0; index < std::min<u64>(end, this->m_entryCount); index++) {
                 entry->clearFormatCache();
-                entry->setVariableName(fmt::format("[{0}]", index));
+                entry->setVariableName(this->m_template->getVariableName() + fmt::format("[{0}]", index));
                 entry->setOffset(this->getOffset() + index * this->m_template->getSize());
                 fn(index, *entry);
+            }
+        }
+
+        void setInlined(bool isInlined) override {
+            Inlinable::setInlined(isInlined);
+            if (isInlined) {
+                this->m_template->setVariableName(this->getVariableName());
+            } else {
+                this->m_template->setVariableName("");
             }
         }
 


### PR DESCRIPTION
Inlined array should now show as `<varname>[<index>]` instead of `[<index>]`