### PR TITLE
Use std::make_* instead of constructors

### DIFF
--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -48,10 +48,18 @@ namespace pl::core {
             return this->m_curr[index].column;
         }
 
-        template<typename T>
-        std::unique_ptr<T> create(T *node) {
-            node->setSourceLocation(this->getLine(-1), this->getColumn(-1));
-            return std::unique_ptr<T>(node);
+        template<typename T, typename...Ts>
+        std::unique_ptr<T> create(Ts&&... ts) {
+            auto temp = std::make_unique<T>(std::forward<Ts>(ts)...);
+            temp->setSourceLocation(this->getLine(-1), this->getColumn(-1));
+            return temp;
+        }
+
+        template<typename T, typename...Ts>
+        std::shared_ptr<T> createShared(Ts&&... ts) {
+            auto temp = std::make_shared<T>(std::forward<Ts>(ts)...);
+            temp->setSourceLocation(this->getLine(-1), this->getColumn(-1));
+            return temp;
         }
 
         template<typename T>

--- a/lib/include/pl/helpers/utils.hpp
+++ b/lib/include/pl/helpers/utils.hpp
@@ -113,11 +113,9 @@ namespace pl::hlp {
     }
 
     template<typename T, typename... Args>
-    void moveToVector(std::vector<T> &buffer, T &&first, Args &&...rest) {
-        buffer.push_back(std::move(first));
-
-        if constexpr (sizeof...(rest) > 0)
-            moveToVector(buffer, std::move(rest)...);
+    void moveToVector(std::vector<T> & buffer, Args &&...rest) {
+        buffer.reserve(sizeof...(rest));
+        (buffer.push_back(std::move(rest)),...);
     }
 
     template<typename T, typename... Args>


### PR DESCRIPTION
I wanted to see, how often a `std::unique_ptr` is assigned to a `std::shared_ptr`, which I now know that it happens only in a few places. 

This PR changes the `create` function in order to create the smart pointers directly instead of taking a pointer and also splits the function into two version. `create` still returns a `std::unique_ptr`, whereas `createShared` now returns a `std::shared_ptr`.

This PR also changes the `moveToVector` in order to use a fold expression instead of a recursion. It is such a small changed, that I did not want to open another PR for it.