### PR TITLE
`Match` keyword for rust like match

### DIFF
--- a/lib/include/pl/core/ast/ast_node_match_statement.hpp
+++ b/lib/include/pl/core/ast/ast_node_match_statement.hpp
@@ -138,7 +138,7 @@ namespace pl::core::ast {
                 auto &condition = m_cases[i].condition;
                 if(evaluateCondition(condition, evaluator)) {
                     if(matchedBody.has_value())
-                        err::E0011.throwError(fmt::format("Match is ambiguous. Both case {} and {} match.", matchedBody.value() + 1, i + 1), {}, condition.get());
+                        err::E0013.throwError(fmt::format("Match is ambiguous. Both case {} and {} match.", matchedBody.value() + 1, i + 1), {}, condition.get());
                     matchedBody = i;
                 }
             }

--- a/lib/include/pl/core/errors/evaluator_errors.hpp
+++ b/lib/include/pl/core/errors/evaluator_errors.hpp
@@ -26,5 +26,6 @@ namespace pl::core::err {
     const static inline EvaluatorError E0010(10, "Control flow error.");
     const static inline EvaluatorError E0011(11, "Memory error.");
     const static inline EvaluatorError E0012(12, "Built-in function error.");
+    const static inline EvaluatorError E0013(13, "Ambiguity error.");
 
 }

--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -137,6 +137,7 @@ namespace pl::core {
         std::unique_ptr<ast::ASTNode> parseFunctionControlFlowStatement();
         std::vector<std::unique_ptr<ast::ASTNode>> parseStatementBody();
         std::unique_ptr<ast::ASTNode> parseFunctionConditional();
+        std::unique_ptr<ast::ASTNode> parseFunctionMatch();
         std::unique_ptr<ast::ASTNode> parseFunctionWhileLoop();
         std::unique_ptr<ast::ASTNode> parseFunctionForLoop();
 

--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -105,6 +105,7 @@ namespace pl::core {
             return result;
         }
 
+        std::vector<std::unique_ptr<ast::ASTNode>> parseParameters();
         std::unique_ptr<ast::ASTNode> parseFunctionCall();
         std::unique_ptr<ast::ASTNode> parseStringLiteral();
         std::string parseNamespaceResolution();
@@ -141,6 +142,7 @@ namespace pl::core {
 
         void parseAttribute(ast::Attributable *currNode);
         std::unique_ptr<ast::ASTNode> parseConditional();
+        std::unique_ptr<ast::ASTNode> parseMatchStatement();
         std::unique_ptr<ast::ASTNode> parseWhileStatement();
         std::unique_ptr<ast::ASTNodeTypeDecl> parseType();
         std::vector<std::shared_ptr<ast::ASTNode>> parseTemplateList();

--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -142,7 +142,7 @@ namespace pl::core {
 
         void parseAttribute(ast::Attributable *currNode);
         std::unique_ptr<ast::ASTNode> parseConditional();
-        std::unique_ptr<ast::ASTNode> parseCaseParameters(std::vector<std::unique_ptr<ast::ASTNode>> &condition);
+        std::pair<std::unique_ptr<ast::ASTNode>, bool> parseCaseParameters(std::vector<std::unique_ptr<ast::ASTNode>> &condition);
         std::unique_ptr<ast::ASTNode> parseMatchStatement();
         std::unique_ptr<ast::ASTNode> parseWhileStatement();
         std::unique_ptr<ast::ASTNodeTypeDecl> parseType();

--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -142,6 +142,7 @@ namespace pl::core {
 
         void parseAttribute(ast::Attributable *currNode);
         std::unique_ptr<ast::ASTNode> parseConditional();
+        std::unique_ptr<ast::ASTNode> parseCaseParameters(std::vector<std::unique_ptr<ast::ASTNode>> &condition);
         std::unique_ptr<ast::ASTNode> parseMatchStatement();
         std::unique_ptr<ast::ASTNode> parseWhileStatement();
         std::unique_ptr<ast::ASTNodeTypeDecl> parseType();

--- a/lib/include/pl/core/token.hpp
+++ b/lib/include/pl/core/token.hpp
@@ -89,6 +89,7 @@ namespace pl::core {
             BoolXor,
             BoolNot,
             TernaryConditional,
+            Underscore,
             Dollar,
             AddressOf,
             SizeOf,
@@ -300,6 +301,7 @@ namespace pl::core {
             constexpr auto SizeOf                   = createToken(core::Token::Type::Operator, Token::Operator::SizeOf);
             constexpr auto At                       = createToken(core::Token::Type::Operator, Token::Operator::At);
             constexpr auto Assign                   = createToken(core::Token::Type::Operator, Token::Operator::Assign);
+            constexpr auto Underscore               = createToken(core::Token::Type::Operator, Token::Operator::Underscore);
 
         }
 

--- a/lib/include/pl/core/token.hpp
+++ b/lib/include/pl/core/token.hpp
@@ -48,6 +48,8 @@ namespace pl::core {
             Parent,
             This,
             While,
+            Match,
+            Default,
             For,
             Function,
             Return,
@@ -230,6 +232,8 @@ namespace pl::core {
             constexpr auto Else         = createToken(core::Token::Type::Keyword, Token::Keyword::Else);
             constexpr auto While        = createToken(core::Token::Type::Keyword, Token::Keyword::While);
             constexpr auto For          = createToken(core::Token::Type::Keyword, Token::Keyword::For);
+            constexpr auto Match        = createToken(core::Token::Type::Keyword, Token::Keyword::Match);
+            constexpr auto Default      = createToken(core::Token::Type::Keyword, Token::Keyword::Default);
             constexpr auto Return       = createToken(core::Token::Type::Keyword, Token::Keyword::Return);
             constexpr auto Break        = createToken(core::Token::Type::Keyword, Token::Keyword::Break);
             constexpr auto Continue     = createToken(core::Token::Type::Keyword, Token::Keyword::Continue);

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -424,6 +424,9 @@ namespace pl::core {
                 } else if (c == '%') {
                     addToken(tkn::Operator::Percent);
                     offset += 1;
+                } else if (c == '_') {
+                    addToken(tkn::Operator::Underscore);
+                    offset += 1;
                 } else if (code.substr(offset, 2) == "<<") {
                     addToken(tkn::Operator::LeftShift);
                     offset += 2;

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -504,6 +504,10 @@ namespace pl::core {
                         addToken(tkn::Keyword::LittleEndian);
                     else if (identifier == "if")
                         addToken(tkn::Keyword::If);
+                    else if (identifier == "match")
+                        addToken(tkn::Keyword::Match);
+                    else if (identifier == "default")
+                        addToken(tkn::Keyword::Default);
                     else if (identifier == "else")
                         addToken(tkn::Keyword::Else);
                     else if (identifier == "false")

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -679,6 +679,9 @@ namespace pl::core {
                 err::P0002.throwError(fmt::format("Expected '(', got {}.", getFormattedToken(0)), {}, 1);
 
             auto [caseCondition, isDefault] = parseCaseParameters(condition);
+            if(!MATCHES(sequence(tkn::Operator::Colon)))
+                err::P0002.throwError(fmt::format("Expected ':', got {}.", getFormattedToken(0)), {}, 1);
+
             auto body = parseStatementBody();
 
             if(isDefault)
@@ -833,11 +836,14 @@ namespace pl::core {
             auto [caseCondition, isDefault] = parseCaseParameters(condition);
             std::vector<std::unique_ptr<ast::ASTNode>> body;
 
-            if (MATCHES(sequence(tkn::Separator::LeftBrace))) {
+            if (MATCHES(sequence(tkn::Operator::Colon, tkn::Separator::LeftBrace))) {
                 while (!MATCHES(sequence(tkn::Separator::RightBrace))) {
                     body.push_back(parseMember());
                 }
-            } else body.push_back(parseMember());
+            } else if (MATCHES(sequence(tkn::Operator::Colon))) {
+                body.push_back(parseMember());
+            } else
+                err::P0002.throwError(fmt::format("Expected ':' after case condition, got {}.", getFormattedToken(0)), {}, 1);
 
             if(isDefault)
                 defaultCase = ast::MatchCase(std::move(caseCondition), std::move(body));

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -764,7 +764,7 @@ namespace pl::core {
 
         // concat all conditions using BoolAnd
         auto cond = std::move(compiledConditions[0]);
-        for(size_t j = 1; i < compiledConditions.size(); j++) {
+        for(size_t j = 1; j < compiledConditions.size(); j++) {
             cond = create<ast::ASTNodeMathematicalExpression>(
                     std::move(cond), std::move(compiledConditions[j]), Token::Operator::BoolAnd);
         }

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -271,6 +271,7 @@ namespace pl::core {
                                       case AddressOf: return "addressof";
                                       case SizeOf: return "sizeof";
                                       case ScopeResolution: return "::";
+                                      case Underscore: return "_";
                                   }
 
                                   return "";

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -195,6 +195,8 @@ namespace pl::core {
                                       case Union: return "union";
                                       case Using: return "using";
                                       case Enum: return "enum";
+                                      case Match: return "match";
+                                      case Default: return "default";
                                       case Bitfield: return "bitfield";
                                       case LittleEndian: return "le";
                                       case BigEndian: return "be";


### PR DESCRIPTION
## Added features:
Struct match feature:
```rust
struct a {
	u8 badge;
        u8 type;
	match(badge, type) {
                (0x10, 0x20) : {
                   u8 size; 
                }
                (0x10, _) : {
                   u16 completeSize;
                 }
	}
};
```

Function match feature:
```rust
#include <std/io.pat>

fn main() {
    u8 type @ 0x0;
    match(type) {
        (0) : std::print("Type is 0");
        (1) : std::print("Type is 1");
        (_) : std::print("Unknown type");
    }
};
```

Syntax:
`match (expression**) { ((literal**)  : statement?|{statement**} }`