### PR TITLE
Added math::accumulate

### DIFF
--- a/lib/include/pl/helpers/buffer.hpp
+++ b/lib/include/pl/helpers/buffer.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <span>
+#include <vector>
+#include <pl.hpp>
+
+#include <pl/helpers/types.hpp>
+
+namespace pl::hlp::bf {
+
+    constexpr static inline unsigned long long operator""_Bytes(unsigned long long bytes) noexcept {
+        return bytes;
+    }
+
+    constexpr static inline unsigned long long operator""_KiB(unsigned long long kiB) noexcept {
+        return operator""_Bytes(kiB * 1024);
+    }
+
+    constexpr static inline unsigned long long operator""_MiB(unsigned long long MiB) noexcept {
+        return operator""_KiB(MiB * 1024);
+    }
+
+    constexpr static inline unsigned long long operator""_GiB(unsigned long long GiB) noexcept {
+        return operator""_MiB(GiB * 1024);
+    }
+
+    class BufferedReader {
+    public:
+        explicit BufferedReader(core::Evaluator* ctx, size_t bufferSize = 16_MiB, u64 sectionId = ptrn::Pattern::MainSectionId)
+                : m_provider(ctx), m_bufferAddress(ctx->getDataBaseAddress()), m_section(sectionId),
+                  m_maxBufferSize(bufferSize),
+                  m_endAddress(ctx->getDataBaseAddress() + ctx->getDataSize() - 1LLU), m_buffer(bufferSize) {
+
+        }
+
+        void seek(u64 address) {
+            this->m_bufferAddress += address;
+        }
+
+        void setEndAddress(u64 address) {
+            if (address >= this->m_provider->getDataSize())
+                address = this->m_provider->getDataSize() - 1;
+
+            this->m_endAddress = address;
+        }
+
+        [[nodiscard]] std::vector<u8> read(u64 address, size_t size) {
+            if (size > this->m_buffer.size()) {
+                std::vector<u8> result;
+                result.resize(size);
+
+                this->m_provider->readData(address, result.data(), result.size(), this->m_section);
+
+                return result;
+            }
+
+            this->updateBuffer(address, size);
+
+            auto result = &this->m_buffer[address -  this->m_bufferAddress];
+
+            return { result, result + std::min(size, this->m_buffer.size()) };
+        }
+
+    private:
+        void updateBuffer(u64 address, size_t size) {
+            if (address > this->m_endAddress)
+                return;
+
+            if (!this->m_bufferValid || address < this->m_bufferAddress || address + size > (this->m_bufferAddress + this->m_buffer.size())) {
+                const auto remainingBytes = (this->m_endAddress - address) + 1;
+                if (remainingBytes < this->m_maxBufferSize)
+                    this->m_buffer.resize(remainingBytes);
+                else
+                    this->m_buffer.resize(this->m_maxBufferSize);
+
+                this->m_provider->readData(address, this->m_buffer.data(), this->m_buffer.size(), this->m_section);
+                this->m_bufferAddress = address;
+                this->m_bufferValid = true;
+            }
+        }
+
+    private:
+        core::Evaluator *m_provider;
+
+        u64 m_bufferAddress = 0x00;
+        u64 m_section;
+        size_t m_maxBufferSize;
+        bool m_bufferValid = false;
+        u64 m_endAddress;
+        std::vector<u8> m_buffer;
+    };
+}

--- a/lib/include/pl/helpers/buffer.hpp
+++ b/lib/include/pl/helpers/buffer.hpp
@@ -8,25 +8,9 @@
 
 namespace pl::hlp::bf {
 
-    constexpr static inline unsigned long long operator""_Bytes(unsigned long long bytes) noexcept {
-        return bytes;
-    }
-
-    constexpr static inline unsigned long long operator""_KiB(unsigned long long kiB) noexcept {
-        return operator""_Bytes(kiB * 1024);
-    }
-
-    constexpr static inline unsigned long long operator""_MiB(unsigned long long MiB) noexcept {
-        return operator""_KiB(MiB * 1024);
-    }
-
-    constexpr static inline unsigned long long operator""_GiB(unsigned long long GiB) noexcept {
-        return operator""_MiB(GiB * 1024);
-    }
-
     class BufferedReader {
     public:
-        explicit BufferedReader(core::Evaluator* ctx, size_t bufferSize = 16_MiB, u64 sectionId = ptrn::Pattern::MainSectionId)
+        explicit BufferedReader(core::Evaluator* ctx, size_t bufferSize = 0x100'0000, u64 sectionId = ptrn::Pattern::MainSectionId)
                 : m_provider(ctx), m_bufferAddress(ctx->getDataBaseAddress()), m_section(sectionId),
                   m_maxBufferSize(bufferSize),
                   m_endAddress(ctx->getDataBaseAddress() + ctx->getDataSize() - 1LLU), m_buffer(bufferSize) {

--- a/lib/source/pl/lib/std/math.cpp
+++ b/lib/source/pl/lib/std/math.cpp
@@ -1,3 +1,5 @@
+#include <numeric>
+
 #include <pl.hpp>
 
 #include <pl/core/token.hpp>
@@ -5,20 +7,16 @@
 #include <pl/core/evaluator.hpp>
 #include <pl/patterns/pattern.hpp>
 #include <pl/helpers/buffer.hpp>
-#include <numeric>
-#include "pl/lib/std/types.hpp"
-
-#define BUFFER_THRESHOLD 0x3000
-#define CHUNKS 20
+#include <pl/lib/std/types.hpp>
 
 namespace pl::lib::libstd::math {
 
-    enum AccumulationOperation {
-        ADD,
-        MULTIPLY,
-        MODULO,
-        MIN,
-        MAX
+    enum class AccumulationOperation {
+        Add,
+        Multiply,
+        Modulo,
+        Min,
+        Max
     };
 
     void registerFunctions(pl::PatternLanguage &runtime) {
@@ -155,7 +153,7 @@ namespace pl::lib::libstd::math {
                 auto start = params[0].toUnsigned();
                 auto end = params[1].toUnsigned();
                 auto size = params[2].toUnsigned();
-                AccumulationOperation op = ADD;
+                AccumulationOperation op = Add;
                 if(params.size() > 3) {
                     op = static_cast<AccumulationOperation>(params[3].toUnsigned());
                 }
@@ -164,10 +162,13 @@ namespace pl::lib::libstd::math {
                     endian = static_cast<types::Endian>(params[4].toUnsigned());
                 }
 
+                if(size > 16) {
+                    err::E0003.throwError("Size cannot be bigger than sizeof(u128)", {}, 0);
+                }
+ 
                 u128 result = 0;
                 u128 endAddr = end / size;
-                using namespace hlp::bf;
-                auto reader = BufferedReader(ctx);
+                auto reader = hlp::bf::BufferedReader(ctx);
                 reader.seek(start);
                 reader.setEndAddress(end);
                 for(u128 addr = start; addr < endAddr; ++addr) {
@@ -178,11 +179,11 @@ namespace pl::lib::libstd::math {
                     // swap endianess
                     value = hlp::changeEndianess(value, size, endian);
                     switch (op) {
-                        case ADD: result += value; break;
-                        case MULTIPLY: result *= value; break;
-                        case MIN: result = std::min(result, value); break;
-                        case MAX: result = std::max(result, value); break;
-                        case MODULO: result %= value; break;
+                        case Add: result += value; break;
+                        case Multiply: result *= value; break;
+                        case Min: result = std::min(result, value); break;
+                        case Max: result = std::max(result, value); break;
+                        case Modulo: result %= value; break;
                     }
                 }
 

--- a/lib/source/pl/lib/std/math.cpp
+++ b/lib/source/pl/lib/std/math.cpp
@@ -153,7 +153,7 @@ namespace pl::lib::libstd::math {
                 auto start = params[0].toUnsigned();
                 auto end = params[1].toUnsigned();
                 auto size = params[2].toUnsigned();
-                AccumulationOperation op = Add;
+                AccumulationOperation op = AccumulationOperation::Add;
                 if(params.size() > 3) {
                     op = static_cast<AccumulationOperation>(params[3].toUnsigned());
                 }
@@ -179,11 +179,11 @@ namespace pl::lib::libstd::math {
                     // swap endianess
                     value = hlp::changeEndianess(value, size, endian);
                     switch (op) {
-                        case Add: result += value; break;
-                        case Multiply: result *= value; break;
-                        case Min: result = std::min(result, value); break;
-                        case Max: result = std::max(result, value); break;
-                        case Modulo: result %= value; break;
+                        case AccumulationOperation::Add: result += value; break;
+                        case AccumulationOperation::Multiply: result *= value; break;
+                        case AccumulationOperation::Min: result = std::min(result, value); break;
+                        case AccumulationOperation::Max: result = std::max(result, value); break;
+                        case AccumulationOperation::Modulo: result %= value; break;
                     }
                 }
 

--- a/lib/source/pl/lib/std/math.cpp
+++ b/lib/source/pl/lib/std/math.cpp
@@ -151,33 +151,38 @@ namespace pl::lib::libstd::math {
             /* helper functions */
             runtime.addFunction(nsStdMath, "accumulate", FunctionParameterCount::between(3,5), [](Evaluator *ctx, auto params) -> std::optional<Token::Literal> {
                 auto start = params[0].toUnsigned();
-                auto end = params[1].toUnsigned();
-                auto size = params[2].toUnsigned();
+                auto end   = params[1].toUnsigned();
+                auto size  = params[2].toUnsigned();
+                
                 AccumulationOperation op = AccumulationOperation::Add;
-                if(params.size() > 3) {
+                if (params.size() > 3)
                     op = static_cast<AccumulationOperation>(params[3].toUnsigned());
-                }
+                
                 types::Endian endian = 0;
-                if(params.size() > 4) {
+                if (params.size() > 4)
                     endian = static_cast<types::Endian>(params[4].toUnsigned());
-                }
 
-                if(size > 16) {
+                if (size > 16)
                     err::E0003.throwError("Size cannot be bigger than sizeof(u128)", {}, 0);
-                }
  
                 u128 result = 0;
                 u128 endAddr = end / size;
+
                 auto reader = hlp::bf::BufferedReader(ctx);
                 reader.seek(start);
                 reader.setEndAddress(end);
-                for(u128 addr = start; addr < endAddr; ++addr) {
+
+                for (u128 addr = start; addr < endAddr; ++addr) {
                     auto bytes = reader.read(addr, size);
-                    // copy to u128
+
+                    // Copy bytes to u128
                     u128 value = 0;
                     std::memcpy(&value, bytes.data(), size);
-                    // swap endianess
+
+                    // Swap endianess
                     value = hlp::changeEndianess(value, size, endian);
+
+                    // Accumulate value into result
                     switch (op) {
                         case AccumulationOperation::Add: result += value; break;
                         case AccumulationOperation::Multiply: result *= value; break;

--- a/lib/source/pl/lib/std/math.cpp
+++ b/lib/source/pl/lib/std/math.cpp
@@ -170,7 +170,7 @@ namespace pl::lib::libstd::math {
                 auto reader = BufferedReader(ctx);
                 reader.seek(start);
                 reader.setEndAddress(end);
-                for(u128 addr = 0; addr < endAddr; ++addr) {
+                for(u128 addr = start; addr < endAddr; ++addr) {
                     auto bytes = reader.read(addr, size);
                     // copy to u128
                     u128 value = 0;


### PR DESCRIPTION
## What's new
New math::accumulate function allowing to add, multiply, min, max or modulo over a range, mostly targeted to checksum
functions.
Definition:
```rust
enum Operation : u8 {
   Add,
   Mul,
   Min,
   Max,
   Mod
};

std::math::accumulate(u128 from. u128 to, u128 size, Operation operation = Operation::ADD,  Endian endian = Endian::Native) -> u128
```

## Example
```rust
#include <std/math.pat>
#include <std/io.pat>

fn main() {
   u32 checksum @ 0x00;
   u32 sum = std::math::accumulate(0x00, std::mem::size(), sizeof(u8));
   if(sum != checksum) {
        std::print("Checksum incorrect");
   }
}
```