### PR TITLE
Allow bitfields to use conditionals correctly, and fix big-endian bitfield oddities.

### DIFF
--- a/lib/include/pl/core/ast/ast_node_bitfield.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield.hpp
@@ -33,8 +33,8 @@ namespace pl::core::ast {
                 bitfieldPattern->setEndian(std::endian::big);
             else if (this->hasAttribute("right_to_left", false))
                 bitfieldPattern->setEndian(std::endian::little);
-            else {
-                switch (evaluator->getBitfieldOrder()) {
+            else if (evaluator->getBitfieldOrder().has_value()) {
+                switch (evaluator->getBitfieldOrder().value()) {
                 case BitfieldOrder::LeftToRight:
                     bitfieldPattern->setEndian(std::endian::big);
                     break;

--- a/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
@@ -45,6 +45,8 @@ namespace pl::core::ast {
             pattern->setPadding(this->isPadding());
             pattern->setVariableName(this->getName());
 
+            evaluator->getBitfieldFieldAddedCallback()(*this, pattern);
+
             return hlp::moveToVector<std::shared_ptr<ptrn::Pattern>>({ std::move(pattern) });
         }
 

--- a/lib/include/pl/core/ast/ast_node_rvalue.hpp
+++ b/lib/include/pl/core/ast/ast_node_rvalue.hpp
@@ -123,9 +123,10 @@ namespace pl::core::ast {
                 readVariable(evaluator, value, pattern);
                 literal = value;
             } else if (auto bitfieldFieldPattern = dynamic_cast<ptrn::PatternBitfieldField *>(pattern); bitfieldFieldPattern != nullptr) {
-                u64 value = 0;
-                readVariable(evaluator, value, pattern);
-                literal = u128(hlp::extract(bitfieldFieldPattern->getBitOffset() + (bitfieldFieldPattern->getBitSize() - 1), bitfieldFieldPattern->getBitOffset(), value));
+                if (!bitfieldFieldPattern->canReadValue())
+                    pl::core::err::E0010.throwError("Cannot read a little-endian bitfield before all fields are laid out.", {}, this);
+
+                literal = u128(bitfieldFieldPattern->readValue());
             } else {
                 literal = pattern;
             }

--- a/lib/include/pl/core/ast/ast_node_type_decl.hpp
+++ b/lib/include/pl/core/ast/ast_node_type_decl.hpp
@@ -99,7 +99,8 @@ namespace pl::core::ast {
                 if (pattern == nullptr)
                     continue;
 
-                pattern->setEndian(evaluator->getDefaultEndian());
+                if (!pattern->hasOverriddenEndian())
+                    pattern->setEndian(evaluator->getDefaultEndian());
 
                 if (!this->m_name.empty())
                     pattern->setTypeName(this->m_name);

--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -214,11 +214,11 @@ namespace pl::core {
             return this->m_loopLimit;
         }
 
-        void setBitfieldOrder(BitfieldOrder order) {
+        void setBitfieldOrder(std::optional<BitfieldOrder> order) {
             this->m_bitfieldOrder = order;
         }
 
-        [[nodiscard]] BitfieldOrder getBitfieldOrder() {
+        [[nodiscard]] std::optional<BitfieldOrder> getBitfieldOrder() {
             return this->m_bitfieldOrder;
         }
 
@@ -410,7 +410,7 @@ namespace pl::core {
         std::function<void()> m_breakpointHitCallback = []{ };
         std::atomic<DangerousFunctionPermission> m_allowDangerousFunctions = DangerousFunctionPermission::Ask;
         ControlFlowStatement m_currControlFlowStatement = ControlFlowStatement::None;
-        BitfieldOrder m_bitfieldOrder = BitfieldOrder::RightToLeft;
+        std::optional<BitfieldOrder> m_bitfieldOrder;
         std::function<void(const ast::ASTNodeBitfieldField&, std::shared_ptr<ptrn::PatternBitfieldField>)> m_bitfieldFieldAddedCallback = [](const ast::ASTNodeBitfieldField&, std::shared_ptr<ptrn::PatternBitfieldField>){ };
 
         std::vector<std::shared_ptr<ptrn::Pattern>> m_patterns;

--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -19,12 +19,16 @@ namespace pl::ptrn {
 
     class Pattern;
     class PatternCreationLimiter;
+    class PatternBitfieldField;
 
 }
 
 namespace pl::core {
 
-    namespace ast { class ASTNode; }
+    namespace ast {
+        class ASTNode;
+        class ASTNodeBitfieldField;
+    }
 
     enum class DangerousFunctionPermission {
         Ask,
@@ -218,6 +222,14 @@ namespace pl::core {
             return this->m_bitfieldOrder;
         }
 
+        void setBitfieldFieldAddedCallback(std::function<void(const ast::ASTNodeBitfieldField&, std::shared_ptr<ptrn::PatternBitfieldField>)> callback) {
+            this->m_bitfieldFieldAddedCallback = callback;
+        }
+
+        [[nodiscard]] std::function<void(const ast::ASTNodeBitfieldField&, std::shared_ptr<ptrn::PatternBitfieldField>)> getBitfieldFieldAddedCallback() {
+            return this->m_bitfieldFieldAddedCallback;
+        }
+
         u64 &dataOffset() { return this->m_currOffset; }
 
         bool addBuiltinFunction(const std::string &name, api::FunctionParameterCount numParams, std::vector<Token::Literal> defaultParameters, const api::FunctionCallback &function, bool dangerous) {
@@ -399,6 +411,7 @@ namespace pl::core {
         std::atomic<DangerousFunctionPermission> m_allowDangerousFunctions = DangerousFunctionPermission::Ask;
         ControlFlowStatement m_currControlFlowStatement = ControlFlowStatement::None;
         BitfieldOrder m_bitfieldOrder = BitfieldOrder::RightToLeft;
+        std::function<void(const ast::ASTNodeBitfieldField&, std::shared_ptr<ptrn::PatternBitfieldField>)> m_bitfieldFieldAddedCallback = [](const ast::ASTNodeBitfieldField&, std::shared_ptr<ptrn::PatternBitfieldField>){ };
 
         std::vector<std::shared_ptr<ptrn::Pattern>> m_patterns;
 

--- a/lib/include/pl/helpers/utils.hpp
+++ b/lib/include/pl/helpers/utils.hpp
@@ -42,30 +42,6 @@ namespace pl::hlp {
 
     std::string encodeByteString(const std::vector<u8> &bytes);
 
-    [[nodiscard]] constexpr inline u64 extract(u8 from, u8 to, const pl::unsigned_integral auto &value) {
-        if (from < to) std::swap(from, to);
-
-        using ValueType = std::remove_cvref_t<decltype(value)>;
-        ValueType mask  = (std::numeric_limits<ValueType>::max() >> (((sizeof(value) * 8) - 1) - (from - to))) << to;
-
-        return (value & mask) >> to;
-    }
-
-    [[nodiscard]] inline u64 extract(u32 from, u32 to, const std::vector<u8> &bytes) {
-        u8 index = 0;
-        while (from > 32 && to > 32) {
-            from -= 8;
-            to -= 8;
-            index++;
-        }
-
-        u64 value = 0;
-        std::memcpy(&value, &bytes[index], std::min(sizeof(value), bytes.size() - index));
-        u64 mask = (std::numeric_limits<u64>::max() >> (64 - (from + 1)));
-
-        return (value & mask) >> to;
-    }
-
     [[nodiscard]] constexpr inline i128 signExtend(size_t numBits, i128 value) {
         i128 mask = u128(1) << u128(numBits - 1);
         return (value ^ mask) - mask;

--- a/lib/source/pl/lib/std/core.cpp
+++ b/lib/source/pl/lib/std/core.cpp
@@ -112,6 +112,9 @@ namespace pl::lib::libstd::core {
                     case 1:
                         ctx->setBitfieldOrder(pl::core::BitfieldOrder::RightToLeft);
                         break;
+                    case 2:
+                        ctx->setBitfieldOrder({});
+                        break;
                     default:
                         err::E0012.throwError("Invalid endian value.", "Try one of the values in the std::core::BitfieldOrder enum.");
                 }
@@ -121,14 +124,16 @@ namespace pl::lib::libstd::core {
 
             /* get_bitfield_order() -> order */
             runtime.addFunction(nsStdCore, "get_bitfield_order", FunctionParameterCount::none(), [](Evaluator *ctx, auto) -> std::optional<Token::Literal> {
-                switch (ctx->getBitfieldOrder()) {
-                    case pl::core::BitfieldOrder::LeftToRight:
-                        return 0;
-                    case pl::core::BitfieldOrder::RightToLeft:
-                        return 1;
+                if (ctx->getBitfieldOrder().has_value()) {
+                    switch (ctx->getBitfieldOrder().value()) {
+                        case pl::core::BitfieldOrder::LeftToRight:
+                            return 0;
+                        case pl::core::BitfieldOrder::RightToLeft:
+                            return 1;
+                    }
                 }
 
-                return std::nullopt;
+                return 2;
             });
 
             /* array_index() -> index */

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -275,7 +275,7 @@ namespace pl {
 
         this->m_internals.evaluator->getConsole().clear();
         this->m_internals.evaluator->setDefaultEndian(this->m_defaultEndian);
-        this->m_internals.evaluator->setBitfieldOrder(core::BitfieldOrder::RightToLeft);
+        this->m_internals.evaluator->setBitfieldOrder({});
         this->m_internals.evaluator->setEvaluationDepth(32);
         this->m_internals.evaluator->setArrayLimit(0x10000);
         this->m_internals.evaluator->setPatternLimit(0x20000);

--- a/tests/include/test_patterns/test_pattern_bitfields.hpp
+++ b/tests/include/test_patterns/test_pattern_bitfields.hpp
@@ -19,6 +19,11 @@ namespace pl::test {
                 bitfieldFields.push_back(create<PatternBitfieldField>("", "d", 0x12, 12, 4, testBitfield.get()));
             }
 
+            for (auto &field : bitfieldFields) {
+                if (auto* bitfieldField = dynamic_cast<PatternBitfieldField*>(field.get()))
+                    bitfieldField->setBitfieldBitSize(4 * 4);
+            }
+
             testBitfield->setFields(std::move(bitfieldFields));
             testBitfield->setEndian(std::endian::big);
 
@@ -37,10 +42,10 @@ namespace pl::test {
 
                 be TestBitfield testBitfield @ 0x12;
 
-                std::assert(testBitfield.a == 0x04, "Field A invalid");
-                std::assert(testBitfield.b == 0x03, "Field B invalid");
-                std::assert(testBitfield.c == 0x0A, "Field C invalid");
-                std::assert(testBitfield.d == 0x00, "Field D invalid");
+                std::assert(testBitfield.a == 0x00, "Field A invalid");
+                std::assert(testBitfield.b == 0x0A, "Field B invalid");
+                std::assert(testBitfield.c == 0x03, "Field C invalid");
+                std::assert(testBitfield.d == 0x04, "Field D invalid");
             )";
         }
     };


### PR DESCRIPTION
This changes big-endian (`left_to_right`) bitfields to be read in big-endian order, which allows variables to be referenced in the logical order that they are declared. In the process, this also fixes an issue where bitfields would skip the first bits in a non-byte-sized big-endian bitfields to align it to the rightmost byte.

Bitfields' fields are now tracked in descendant AST nodes, meaning that bitfield offsets for conditional fields will no longer be zero. This should allow conditional reads in bitfields to work as one would expect.