### PR TITLE
Add std::core::set_dislpay_name function

### DIFF
--- a/lib/source/pl/lib/std/core.cpp
+++ b/lib/source/pl/lib/std/core.cpp
@@ -60,6 +60,16 @@ namespace pl::lib::libstd::core {
                 return std::nullopt;
             });
 
+            /* set_display_name(pattern, name) */
+            runtime.addFunction(nsStdCore, "set_dislpay_name", FunctionParameterCount::exactly(2), [](Evaluator *, auto params) -> std::optional<Token::Literal> {
+                auto pattern = params[0].toPattern();
+                auto name = params[1].toString(false);
+
+                pattern->setDisplayName(name);
+
+                return std::nullopt;
+            });
+
             /* set_pattern_comment(pattern, comment) */
             runtime.addFunction(nsStdCore, "set_pattern_comment", FunctionParameterCount::exactly(2), [](Evaluator *, auto params) -> std::optional<Token::Literal> {
                 auto pattern = params[0].toPattern();


### PR DESCRIPTION
Same as for `set_pattern_comment` sometimes you need to do something more dynamic and complex than rather static `[[name("some_name")]]`. Having `builtin::std::core::set_dislpay_name()` available we will be able to have a post processing step in `fn main()` that will have full access to every node and you can give child node name that depends on parent node that also relies on some post processing.

e.g. for ELF files:

```c
/* contents of patterns/elf.hexpat */
ELF elf @ 0x00;

fn gen_shdr_disp_name(ref auto pattern,
                    str member_name,
                    u8 member_index) {
    return std::format(
        "{}@shdr[{}]({})",
        member_name,
        member_index,
        format_section_header(pattern)
    );
};

fn main() {
    for (u8 i = 0, i < member_count(elf.shdr), i = i + 1) {
        if (has_member(elf.shdr[i], "data")) {
            builtin::std::core::set_dislpay_name(
                elf.shdr[i].data,
                gen_shdr_disp_name(elf.shdr[i], "data", i)
            );
        }
    }
}
```
Explanation: ELF file's section names are stored in string table section, that is not the first section you parse. The only way to  give sections meaningful display names is by having a post process step.

For more details see https://github.com/WerWolv/ImHex-Patterns/pull/92
