### PR TITLE
Add missing `<unordered_map>` include

### DIFF
--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <memory>
 #include <unordered_set>
+#include <unordered_map>
 
 #include <pl/core/log_console.hpp>
 #include <pl/core/token.hpp>


### PR DESCRIPTION
To avoid relying on transitive includes here.