### PR TITLE
Fix writing big endian values

### DIFF
--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -336,9 +336,9 @@ namespace pl::ptrn {
 
         virtual std::vector<u8> getBytesOf(const core::Token::Literal &value) const {
             auto bytes = value.toBytes();
+            bytes.resize(this->getSize());
             if (this->getEndian() == std::endian::big)
                 std::reverse(bytes.begin(), bytes.end());
-            bytes.resize(this->getSize());
 
             return bytes;
         }


### PR DESCRIPTION
The reversal of bytes to account for big endian values was being done before shrinking the vector to the right size, causing data to go missing.