### PR TITLE
Fix refcounting of pattern-local variables

### DIFF
--- a/lib/include/pl/core/ast/ast_node_variable_decl.hpp
+++ b/lib/include/pl/core/ast/ast_node_variable_decl.hpp
@@ -75,31 +75,31 @@ namespace pl::core::ast {
                     err::E0005.throwError(fmt::format("Cannot place variable '{}' at out of bounds address 0x{:08X}", this->m_name, evaluator->dataOffset()), { }, this);
             }
 
-            auto patterns = this->m_type->createPatterns(evaluator);
-            if (patterns.empty())
-                err::E0005.throwError("'auto' can only be used with parameters.", { }, this);
-
-            auto &pattern = patterns.front();
-            if (this->m_placementOffset != nullptr && dynamic_cast<ptrn::PatternString*>(pattern.get()) != nullptr)
-                err::E0005.throwError(fmt::format("Variables of type 'str' cannot be placed in memory.", this->m_name), { }, this);
-
-            pattern->setVariableName(this->m_name);
-
-            if (this->m_placementSection != nullptr)
-                pattern->setSection(evaluator->getSectionId());
-
-            applyVariableAttributes(evaluator, this, pattern);
-
-
-            if (this->m_placementOffset != nullptr && !evaluator->isGlobalScope()) {
-                evaluator->dataOffset() = startOffset;
-            }
-
             if (evaluator->getSectionId() == ptrn::Pattern::PatternLocalSectionId) {
                 evaluator->dataOffset() = startOffset;
                 this->execute(evaluator);
                 return { };
             } else {
+                auto patterns = this->m_type->createPatterns(evaluator);
+                if (patterns.empty())
+                    err::E0005.throwError("'auto' can only be used with parameters.", { }, this);
+
+                auto &pattern = patterns.front();
+                if (this->m_placementOffset != nullptr && dynamic_cast<ptrn::PatternString*>(pattern.get()) != nullptr)
+                    err::E0005.throwError(fmt::format("Variables of type 'str' cannot be placed in memory.", this->m_name), { }, this);
+
+                pattern->setVariableName(this->m_name);
+
+                if (this->m_placementSection != nullptr)
+                    pattern->setSection(evaluator->getSectionId());
+
+                applyVariableAttributes(evaluator, this, pattern);
+
+
+                if (this->m_placementOffset != nullptr && !evaluator->isGlobalScope()) {
+                    evaluator->dataOffset() = startOffset;
+                }
+
                 return hlp::moveToVector<std::shared_ptr<ptrn::Pattern>>(std::move(pattern));
             }
         }

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -91,7 +91,13 @@ namespace pl::ptrn {
         [[nodiscard]] virtual u64 getOffsetForSorting() const { return this->getOffset(); }
         [[nodiscard]] u32 getHeapAddress() const { return this->getOffset() >> 32; }
         virtual void setOffset(u64 offset) {
-            this->m_offset = offset;
+            if (this->m_offset != offset) {
+                if (this->m_evaluator)
+                    this->m_evaluator->patternDestroyed(this);
+                this->m_offset = offset;
+                if (this->m_evaluator)
+                    this->m_evaluator->patternCreated(this);
+            }
         }
 
         [[nodiscard]] size_t getSize() const { return this->m_size; }
@@ -267,9 +273,9 @@ namespace pl::ptrn {
         virtual void setLocal(bool local) {
             if (local) {
                 this->setEndian(std::endian::native);
-                this->m_section = HeapSectionId;
+                this->setSection(HeapSectionId);
             } else {
-                this->m_section = MainSectionId;
+                this->setSection(MainSectionId);
             }
         }
 
@@ -290,7 +296,13 @@ namespace pl::ptrn {
         }
 
         virtual void setSection(u64 id) {
-            this->m_section = id;
+            if (this->m_section != id) {
+                if (this->m_evaluator)
+                    this->m_evaluator->patternDestroyed(this);
+                this->m_section = id;
+                if (this->m_evaluator)
+                    this->m_evaluator->patternCreated(this);
+            }
         }
 
         [[nodiscard]] u64 getSection() const {

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -169,8 +169,8 @@ namespace pl::core {
                 pattern->setOffset(heapAddress << 32);
                 this->getHeap()[heapAddress].resize(pattern->getSize());
             } else if (sectionId == ptrn::Pattern::PatternLocalSectionId) {
-                pattern->setSection(sectionId);
                 pattern->setOffset(u64(patternLocalAddress) << 32);
+                pattern->setSection(sectionId);
                 this->m_patternLocalStorage[patternLocalAddress].data.resize(pattern->getSize());
             }
         }

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -591,13 +591,13 @@ namespace pl::core {
         this->m_sectionId = 1;
         this->m_outVariables.clear();
 
+        this->m_customFunctions.clear();
+        this->m_patterns.clear();
+
         this->m_scopes.clear();
         this->m_heap.clear();
         this->m_patternLocalStorage.clear();
         this->m_templateParameters.clear();
-
-        this->m_customFunctions.clear();
-        this->m_patterns.clear();
 
         this->m_mainResult.reset();
         this->m_colorIndex = 0;
@@ -779,6 +779,8 @@ namespace pl::core {
                 auto &[key, data] = *it;
 
                 data.referenceCount++;
+            } else {
+                err::E0001.throwError(fmt::format("Attempted to add a reference to deleted variable named '{}'.", pattern->getVariableName()));
             }
         }
     }
@@ -793,6 +795,8 @@ namespace pl::core {
                 data.referenceCount--;
                 if (data.referenceCount == 0)
                     this->m_patternLocalStorage.erase(it);
+            } else {
+                err::E0001.throwError(fmt::format("Double free of variable named '{}'.", pattern->getVariableName()));
             }
         }
     }


### PR DESCRIPTION
This fixes accessing local variables from `ref auto` parameters, like in this example:

```cpp
#include <std/core.pat>

bitfield ZeroBit {
    zeroBit : 1;
    if (zeroBit) {
        break;
    }
} [[inline]];

bitfield ExpGolomb {
    ZeroBit leadingZeros[while (true)] [[sealed]];
    u32 value = (1 < 32) - 1;
    if ((std::core::member_count(leadingZeros) - 1) < 32) {
        valueBits : (std::core::member_count(leadingZeros) - 1) [[name("value")]];
        value = valueBits + (1 << (std::core::member_count(leadingZeros) - 1)) - 1;
    }
} [[format("get_exp_golomb_value"),transform("get_exp_golomb_value")]];
fn get_exp_golomb_value(ref auto exp_golomb) {
    return exp_golomb.value;
};

ExpGolomb e @ 0;
```

Previously, the ref count was starting at 0, decrementing due to an unused pattern in `ASTNodeVariableDecl::createPatterns` and wrapping to the maximum value, then incrementing on entering the formatter function, causing the evaluator to see a 0 ref count and delete the variable's memory.