### PR TITLE
Allow match statements' cases to specify extra conditions

### DIFF
--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -136,9 +136,7 @@ namespace pl::core {
         std::unique_ptr<ast::ASTNode> parseFunctionVariableAssignment(const std::string &lvalue);
         std::unique_ptr<ast::ASTNode> parseFunctionVariableCompoundAssignment(const std::string &lvalue);
         std::unique_ptr<ast::ASTNode> parseFunctionControlFlowStatement();
-        std::vector<std::unique_ptr<ast::ASTNode>> parseStatementBody();
-        std::unique_ptr<ast::ASTNode> parseFunctionConditional();
-        std::unique_ptr<ast::ASTNode> parseFunctionMatch();
+        std::vector<std::unique_ptr<ast::ASTNode>> parseStatementBody(const std::function<std::unique_ptr<ast::ASTNode>()> &memberParser);
         std::unique_ptr<ast::ASTNode> parseFunctionWhileLoop();
         std::unique_ptr<ast::ASTNode> parseFunctionForLoop();
 

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -771,6 +771,14 @@ namespace pl::core {
             err::P0002.throwError("Size of case parameters smaller than size of match condition.", {}, 1);
         }
 
+        if (MATCHES(sequence(tkn::Keyword::If, tkn::Separator::LeftParenthesis))) {
+            auto extraCondition = parseMathematicalExpression();
+            condition = create<ast::ASTNodeMathematicalExpression>(
+                    std::move(condition), std::move(extraCondition), Token::Operator::BoolAnd);
+            if (!MATCHES(sequence(tkn::Separator::RightParenthesis)))
+                err::P0002.throwError(fmt::format("Expected ')' at end of 'if' statement, got {}.", getFormattedToken(0)), {}, 1);
+        }
+
         return {std::move(condition), isDefault};
     }
 


### PR DESCRIPTION
This adds parsing of extra conditional statements on match cases similar to how Rust allows:
```rust
u32 conditionallyRelevant;

struct MatchConditional {
    u8 value;

    match (value) {
        (0): u32 item;
        (1) if (conditionallyRelevant == 0): u64 item;
        (_): u16 item;
    }
}
```

This could also be achieved by the following:
```rust
u32 conditionallyRelevant;

struct MatchConditional {
    u8 value;

    match (value, conditionallyRelevant) {
        (0, _): u32 item;
        (1, 0): u64 item;
        (_, _): u16 item;
    }
}
```
but I think it helps with readability in otherwise long match statements that have a few cases where some other variable is relevant.

This PR also includes some small improvements to the match parsing code.