### PR TITLE
Refer to the correct column when a bitfield body doesn't start with '{'

### DIFF
--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -1445,7 +1445,7 @@ namespace pl::core {
         auto bitfieldNode = static_cast<ast::ASTNodeBitfield *>(typeDecl->getType().get());
 
         if (!MATCHES(sequence(tkn::Separator::LeftBrace)))
-            err::P0002.throwError(fmt::format("Expected '{{' after bitfield declaration, got {}.", getFormattedToken(0)), {}, 1);
+            err::P0002.throwError(fmt::format("Expected '{{' after bitfield declaration, got {}.", getFormattedToken(0)), {}, 0);
 
         while (!MATCHES(sequence(tkn::Separator::RightBrace))) {
             bitfieldNode->addEntry(this->parseBitfieldEntry());


### PR DESCRIPTION
Previously, this would point to the bitfield name instead of the token that caused the error.