### PR TITLE
Allow setting bitfield order with `[[bitfield_order(direction, size)]]`

### DIFF
--- a/lib/include/pl/core/ast/ast_node_attribute.hpp
+++ b/lib/include/pl/core/ast/ast_node_attribute.hpp
@@ -64,6 +64,15 @@ namespace pl::core::ast {
             return this->m_attributes;
         }
 
+        [[nodiscard]] ASTNodeAttribute *getAttributeByName(const std::string &key) const {
+            auto it = std::find_if(this->getAttributes().begin(), this->getAttributes().end(), [&](const std::unique_ptr<ASTNodeAttribute> &attribute) {
+                return attribute->getAttribute() == key;
+            });
+            if (it == this->getAttributes().end())
+                return nullptr;
+            return it->get();
+        }
+
         [[nodiscard]] bool hasAttribute(const std::string &key, bool needsParameter) const {
             return std::any_of(this->m_attributes.begin(), this->m_attributes.end(), [&](const std::unique_ptr<ASTNodeAttribute> &attribute) {
                 if (attribute->getAttribute() == key) {
@@ -80,16 +89,12 @@ namespace pl::core::ast {
         }
 
         [[nodiscard]] const std::vector<std::unique_ptr<ASTNode>>& getAttributeArguments(const std::string &key) const {
-            auto attribute = std::find_if(this->m_attributes.begin(), this->m_attributes.end(), [&](const std::unique_ptr<ASTNodeAttribute> &attribute) {
-                return attribute->getAttribute() == key;
-            });
-
-            if (attribute != this->m_attributes.end())
-                return (*attribute)->getArguments();
-            else {
+            auto *attribute = this->getAttributeByName(key);
+            if (attribute == nullptr) {
                 static std::vector<std::unique_ptr<ASTNode>> empty;
                 return empty;
             }
+            return attribute->getArguments();
         }
 
         [[nodiscard]] std::shared_ptr<ASTNode> getFirstAttributeValue(const std::vector<std::string> &keys) const {

--- a/lib/include/pl/core/ast/ast_node_bitfield.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield.hpp
@@ -11,6 +11,11 @@ namespace pl::core::ast {
     class ASTNodeBitfield : public ASTNode,
                             public Attributable {
     public:
+        enum class BitfieldOrder {
+            MostToLeastSignificant = 0,
+            LeastToMostSignificant = 1,
+        };
+
         ASTNodeBitfield() : ASTNode() { }
 
         ASTNodeBitfield(const ASTNodeBitfield &other) : ASTNode(other), Attributable(other) {
@@ -38,31 +43,74 @@ namespace pl::core::ast {
 
             bitfieldPattern->setSection(evaluator->getSectionId());
 
-            if (this->hasAttribute("left_to_right", false))
-                bitfieldPattern->setEndian(std::endian::big);
-            else if (this->hasAttribute("right_to_left", false))
-                bitfieldPattern->setEndian(std::endian::little);
-            else if (evaluator->getBitfieldOrder().has_value()) {
-                switch (evaluator->getBitfieldOrder().value()) {
-                case BitfieldOrder::LeftToRight:
-                    bitfieldPattern->setEndian(std::endian::big);
-                    break;
-                case BitfieldOrder::RightToLeft:
-                    bitfieldPattern->setEndian(std::endian::little);
-                    break;
+            bool prevReversed = evaluator->isBitfieldReversed();
+            bool didReverse = false;
+            u128 fixedSize = 0;
+
+            {
+                auto *badAttribute = [&]() {
+                    if (auto *ltrAttribute = this->getAttributeByName("left_to_right"); ltrAttribute != nullptr)
+                        return ltrAttribute;
+                    return this->getAttributeByName("right_to_left");
+                }();
+                if (badAttribute != nullptr)
+                    err::E0008.throwError(fmt::format("Attribute '{}' is no longer supported.", badAttribute->getAttribute()), {}, badAttribute);
+            }
+
+            auto *orderAttribute = this->getAttributeByName("bitfield_order");
+            if (orderAttribute != nullptr) {
+                auto &arguments = orderAttribute->getArguments();
+                if (arguments.size() != 2)
+                    err::E0008.throwError(fmt::format("Attribute 'bitfield_order' expected 2 parameters, received {}.", arguments.size()), {}, orderAttribute);
+
+                auto directionNode = arguments[0]->evaluate(evaluator);
+                auto sizeNode = arguments[1]->evaluate(evaluator);
+
+                BitfieldOrder order = [&]() {
+                    if (auto *literalNode = dynamic_cast<ASTNodeLiteral *>(directionNode.get()); literalNode != nullptr) {
+                        auto value = literalNode->getValue().toUnsigned();
+                        switch (value) {
+                        case std::to_underlying(BitfieldOrder::MostToLeastSignificant):
+                            return BitfieldOrder::MostToLeastSignificant;
+                        case std::to_underlying(BitfieldOrder::LeastToMostSignificant):
+                            return BitfieldOrder::LeastToMostSignificant;
+                        default:
+                            err::E0008.throwError(fmt::format("Invalid BitfieldOrder value {}.", value), {}, arguments[0].get());
+                        }
+                    }
+                    err::E0008.throwError("The 'direction' parameter for attribute 'bitfield_order' must not be void.", {}, arguments[0].get());
+                }();
+                u128 size = [&]() {
+                    if (auto *literalNode = dynamic_cast<ASTNodeLiteral *>(sizeNode.get()); literalNode != nullptr) {
+                        auto value = literalNode->getValue().toUnsigned();
+                        if (value == 0)
+                            err::E0008.throwError("Fixed size of a bitfield must be greater than zero.", {}, arguments[1].get());
+                        return value;
+                    }
+                    err::E0008.throwError("The 'size' parameter for attribute 'bitfield_order' must not be void.", {}, arguments[1].get());
+                }();
+
+                bool shouldBeReversed = (order == BitfieldOrder::MostToLeastSignificant && bitfieldPattern->getEndian() == std::endian::little)
+                    || (order == BitfieldOrder::LeastToMostSignificant && bitfieldPattern->getEndian() == std::endian::big);
+                if (prevReversed != shouldBeReversed) {
+                    didReverse = true;
+                    evaluator->incrementBitfieldBitOffset(shouldBeReversed ? size : -size);
+                    evaluator->setBitfieldReversed(shouldBeReversed);
                 }
+
+                fixedSize = size;
             }
 
             std::vector<std::shared_ptr<ptrn::Pattern>> fields;
             std::vector<std::shared_ptr<ptrn::Pattern>> potentialPatterns;
 
-            auto prevDefaultEndian = evaluator->getDefaultEndian();
             evaluator->pushScope(bitfieldPattern, potentialPatterns);
-            evaluator->setDefaultEndian(bitfieldPattern->getEndian());
             ON_SCOPE_EXIT {
-                evaluator->setDefaultEndian(prevDefaultEndian);
                 evaluator->popScope();
             };
+
+            auto initialByteOffset = evaluator->dataOffset();
+            auto initialBitOffset = evaluator->getBitfieldBitOffset();
 
             for (auto &entry : this->m_entries) {
                 auto patterns = entry->createPatterns(evaluator);
@@ -82,33 +130,36 @@ namespace pl::core::ast {
                 }
             }
 
-            if (potentialPatterns.size() > 0) {
-                auto lastMemberIter = std::find_if(potentialPatterns.rbegin(), potentialPatterns.rend(), [](auto& pattern) {
-                    return dynamic_cast<ptrn::PatternBitfieldMember*>(pattern.get()) != nullptr;
-                });
-                if (lastMemberIter != potentialPatterns.rend()) {
-                    auto *lastMember = static_cast<ptrn::PatternBitfieldMember*>(lastMemberIter->get());
-                    auto totalBitSize = (lastMember->getTotalBitOffset() - bitfieldPattern->getTotalBitOffset()) + lastMember->getBitSize();
-                    bitfieldPattern->setBitSize(totalBitSize);
-                }
+            auto startOffset = (initialByteOffset * 8) + initialBitOffset;
+            auto endOffset = (evaluator->dataOffset() * 8) + evaluator->getBitfieldBitOffset();
+            auto totalBitSize = startOffset > endOffset ? startOffset - endOffset : endOffset - startOffset;
+            if (fixedSize > 0) {
+                if (totalBitSize > fixedSize)
+                    err::E0005.throwError("Bitfield's fields exceeded the attribute-allotted size.", {}, this);
+                if (didReverse)
+                    evaluator->incrementBitfieldBitOffset(totalBitSize);
+                totalBitSize = fixedSize;
+            }
+            bitfieldPattern->setBitSize(totalBitSize);
 
-                for (auto &pattern : potentialPatterns) {
-                    if (auto bitfieldMember = dynamic_cast<ptrn::PatternBitfieldMember*>(pattern.get()); bitfieldMember != nullptr) {
-                        bitfieldMember->setParentBitfield(bitfieldPattern.get());
-                        if (!bitfieldMember->isPadding())
-                            fields.push_back(std::move(pattern));
-                    } else {
+            for (auto &pattern : potentialPatterns) {
+                if (auto bitfieldMember = dynamic_cast<ptrn::PatternBitfieldMember*>(pattern.get()); bitfieldMember != nullptr) {
+                    bitfieldMember->setParentBitfield(bitfieldPattern.get());
+                    if (!bitfieldMember->isPadding())
                         fields.push_back(std::move(pattern));
-                    }
+                } else {
+                    fields.push_back(std::move(pattern));
                 }
             }
 
+            bitfieldPattern->setReversed(evaluator->isBitfieldReversed());
             bitfieldPattern->setFields(fields);
 
             applyTypeAttributes(evaluator, this, bitfieldPattern);
 
             if (!this->m_isNested)
                 evaluator->resetBitfieldBitOffset();
+            evaluator->setBitfieldReversed(prevReversed);
 
             return hlp::moveToVector<std::shared_ptr<ptrn::Pattern>>(std::move(bitfieldPattern));
         }

--- a/lib/include/pl/core/ast/ast_node_bitfield_array_variable_decl.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield_array_variable_decl.hpp
@@ -88,6 +88,7 @@ namespace pl::core::ast {
             auto arrayPattern = std::make_unique<ptrn::PatternBitfieldArray>(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), 0);
             arrayPattern->setVariableName(this->m_name);
             arrayPattern->setSection(evaluator->getSectionId());
+            arrayPattern->setReversed(evaluator->isBitfieldReversed());
 
             std::vector<std::shared_ptr<ptrn::Pattern>> entries;
 

--- a/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
@@ -41,12 +41,18 @@ namespace pl::core::ast {
                     [](auto &&offset) -> u8 { return static_cast<u8>(offset); }
             }, literal->getValue());
 
-            auto pattern = std::make_shared<ptrn::PatternBitfieldField>(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), bitSize);
+            std::shared_ptr<ptrn::PatternBitfieldField> pattern;
+            if (evaluator->isBitfieldReversed()) {
+                evaluator->incrementBitfieldBitOffset(-bitSize);
+                pattern = std::make_shared<ptrn::PatternBitfieldField>(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), bitSize);
+            } else {
+                pattern = std::make_shared<ptrn::PatternBitfieldField>(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), bitSize);
+                evaluator->incrementBitfieldBitOffset(bitSize);
+            }
             pattern->setPadding(this->isPadding());
             pattern->setVariableName(this->getName());
 
             pattern->setEndian(evaluator->getDefaultEndian());
-            evaluator->addToBitfieldBitOffset(bitSize);
             pattern->setSection(evaluator->getSectionId());
 
             applyVariableAttributes(evaluator, this, pattern);

--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -43,11 +43,6 @@ namespace pl::core {
         Return
     };
 
-    enum class BitfieldOrder {
-        RightToLeft,
-        LeftToRight
-    };
-
     class Evaluator {
     public:
         Evaluator() = default;
@@ -214,19 +209,15 @@ namespace pl::core {
             return this->m_loopLimit;
         }
 
-        void setBitfieldOrder(std::optional<BitfieldOrder> order) {
-            this->m_bitfieldOrder = order;
-        }
-
-        [[nodiscard]] std::optional<BitfieldOrder> getBitfieldOrder() {
-            return this->m_bitfieldOrder;
-        }
-
         u64 &dataOffset() { return this->m_currOffset; }
 
-        u8 getBitfieldBitOffset() { return this->m_bitfieldBitOffset; }
+        void setBitfieldReversed(bool reversed) { this->m_bitfieldIsReversed = reversed; }
 
-        void addToBitfieldBitOffset(u128 bitSize) {
+        [[nodiscard]] bool isBitfieldReversed() const { return this->m_bitfieldIsReversed; }
+
+        u8 getBitfieldBitOffset() const { return this->m_bitfieldBitOffset; }
+
+        void incrementBitfieldBitOffset(i128 bitSize) {
             this->dataOffset() += bitSize >> 3;
             this->m_bitfieldBitOffset += bitSize & 0x7;
 
@@ -432,8 +423,8 @@ namespace pl::core {
         std::function<void()> m_breakpointHitCallback = []{ };
         std::atomic<DangerousFunctionPermission> m_allowDangerousFunctions = DangerousFunctionPermission::Ask;
         ControlFlowStatement m_currControlFlowStatement = ControlFlowStatement::None;
-        std::optional<BitfieldOrder> m_bitfieldOrder;
-        u8 m_bitfieldBitOffset = 0;
+        bool m_bitfieldIsReversed = false;
+        i8 m_bitfieldBitOffset = 0;
 
         std::vector<std::shared_ptr<ptrn::Pattern>> m_patterns;
 

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -35,10 +35,21 @@ namespace pl::ptrn {
 
         [[nodiscard]] virtual bool isPadding() const { return false; }
 
+        [[nodiscard]] virtual bool isReversed() const { return false; }
+
+        virtual void setReversed(bool reversed) { wolv::util::unused(reversed); }
+
         [[nodiscard]] u64 getOffsetForSorting() const override {
             // If this member has no parent, that means we are sorting in a byte-based context.
-            if (this->getParentBitfield() == nullptr)
+            auto *parent = this->getParentBitfield();
+            if (parent == nullptr)
                 return getOffset();
+
+            if (parent->isReversed()) {
+                auto parentOffset = parent->getTotalBitOffset();
+                auto parentSize = parent->getBitSize();
+                return parentOffset + parentSize - ((this->getTotalBitOffset() - parentOffset) + this->getBitSize());
+            }
 
             return this->getTotalBitOffset();
         }
@@ -180,6 +191,14 @@ namespace pl::ptrn {
 
         [[nodiscard]] u64 getBitSize() const override {
             return this->m_totalBitSize;
+        }
+
+        [[nodiscard]] bool isReversed() const override {
+            return this->m_reversed;
+        }
+
+        void setReversed(bool reversed) override {
+            this->m_reversed = reversed;
         }
 
         void setColor(u32 color) override {
@@ -363,6 +382,7 @@ namespace pl::ptrn {
         u8 m_firstBitOffset = 0;
         u128 m_totalBitSize = 0;
         PatternBitfieldMember *m_parentBitfield = nullptr;
+        bool m_reversed = false;
     };
 
     class PatternBitfield : public PatternBitfieldMember,
@@ -408,6 +428,14 @@ namespace pl::ptrn {
 
         [[nodiscard]] u64 getBitSize() const override {
             return this->m_totalBitSize;
+        }
+
+        [[nodiscard]] bool isReversed() const override {
+            return this->m_reversed;
+        }
+
+        void setReversed(bool reversed) override {
+            this->m_reversed = reversed;
         }
 
         void setSection(u64 id) override {
@@ -589,6 +617,7 @@ namespace pl::ptrn {
         PatternBitfieldMember *m_parentBitfield = nullptr;
         u8 m_firstBitOffset = 0;
         u64 m_totalBitSize = 0;
+        bool m_reversed = false;
     };
 
 }

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -604,6 +604,9 @@ namespace pl::core {
         this->m_aborted = false;
         this->m_evaluated = false;
 
+        this->m_bitfieldIsReversed = false;
+        this->m_bitfieldBitOffset = 0;
+
         if (this->m_allowDangerousFunctions == DangerousFunctionPermission::Deny)
             this->m_allowDangerousFunctions = DangerousFunctionPermission::Ask;
 

--- a/lib/source/pl/lib/std/core.cpp
+++ b/lib/source/pl/lib/std/core.cpp
@@ -101,41 +101,6 @@ namespace pl::lib::libstd::core {
                 return std::nullopt;
             });
 
-            /* set_bitfield_order(order) */
-            runtime.addFunction(nsStdCore, "set_bitfield_order", FunctionParameterCount::exactly(1), [](Evaluator *ctx, auto params) -> std::optional<Token::Literal> {
-                auto endian = params[0].toUnsigned();
-
-                switch (endian) {
-                    case 0:
-                        ctx->setBitfieldOrder(pl::core::BitfieldOrder::LeftToRight);
-                        break;
-                    case 1:
-                        ctx->setBitfieldOrder(pl::core::BitfieldOrder::RightToLeft);
-                        break;
-                    case 2:
-                        ctx->setBitfieldOrder({});
-                        break;
-                    default:
-                        err::E0012.throwError("Invalid endian value.", "Try one of the values in the std::core::BitfieldOrder enum.");
-                }
-
-                return std::nullopt;
-            });
-
-            /* get_bitfield_order() -> order */
-            runtime.addFunction(nsStdCore, "get_bitfield_order", FunctionParameterCount::none(), [](Evaluator *ctx, auto) -> std::optional<Token::Literal> {
-                if (ctx->getBitfieldOrder().has_value()) {
-                    switch (ctx->getBitfieldOrder().value()) {
-                        case pl::core::BitfieldOrder::LeftToRight:
-                            return 0;
-                        case pl::core::BitfieldOrder::RightToLeft:
-                            return 1;
-                    }
-                }
-
-                return 2;
-            });
-
             /* array_index() -> index */
             runtime.addFunction(nsStdCore, "array_index", FunctionParameterCount::none(), [](Evaluator *ctx, auto) -> std::optional<Token::Literal> {
                 auto index = ctx->getCurrentArrayIndex();

--- a/lib/source/pl/lib/std/pragmas.cpp
+++ b/lib/source/pl/lib/std/pragmas.cpp
@@ -2,6 +2,7 @@
 
 #include <pl/core/validator.hpp>
 #include <pl/core/evaluator.hpp>
+#include <pl/core/errors/preprocessor_errors.hpp>
 
 using namespace pl;
 
@@ -70,16 +71,9 @@ namespace pl::lib::libstd {
             return true;
         });
 
-        runtime.addPragma("bitfield_order", [](pl::PatternLanguage &runtime, const std::string &value) {
-            if (value == "left_to_right") {
-                runtime.getInternals().evaluator->setBitfieldOrder(pl::core::BitfieldOrder::LeftToRight);
-                return true;
-            } else if (value == "right_to_left") {
-                runtime.getInternals().evaluator->setBitfieldOrder(pl::core::BitfieldOrder::RightToLeft);
-                return true;
-            } else {
-                return false;
-            }
+        runtime.addPragma("bitfield_order", [](pl::PatternLanguage &, const std::string &) -> bool {
+            core::err::M0006.throwError("Pragma 'bitfield_order' is unsupported.",
+                "Bitfield order can be overridden on a field declaration with the `be` or `le` keywords.");
         });
 
         runtime.addPragma("debug", [](pl::PatternLanguage &runtime, const std::string &value) {

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -275,7 +275,6 @@ namespace pl {
 
         this->m_internals.evaluator->getConsole().clear();
         this->m_internals.evaluator->setDefaultEndian(this->m_defaultEndian);
-        this->m_internals.evaluator->setBitfieldOrder({});
         this->m_internals.evaluator->setEvaluationDepth(32);
         this->m_internals.evaluator->setArrayLimit(0x10000);
         this->m_internals.evaluator->setPatternLimit(0x20000);


### PR DESCRIPTION
This removes the existing bitfield attributes, pragmas and settings in favor of a new attribute that specifies the direction of a bitfield's layout order as starting from either the least significant or most significant bits. In order to facilitate this, the attribute requires a size parameter in bits to be passed, so that if the byte-endianness defines that the starting point is at the last byte in memory, the bitfield can be offset to start there.

Fixes https://github.com/WerWolv/ImHex/issues/981