### PR TITLE
Allow a case to contain multiple `...` ranges separated by `|`

### DIFF
--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -136,9 +136,7 @@ namespace pl::core {
         std::unique_ptr<ast::ASTNode> parseFunctionVariableAssignment(const std::string &lvalue);
         std::unique_ptr<ast::ASTNode> parseFunctionVariableCompoundAssignment(const std::string &lvalue);
         std::unique_ptr<ast::ASTNode> parseFunctionControlFlowStatement();
-        std::vector<std::unique_ptr<ast::ASTNode>> parseStatementBody();
-        std::unique_ptr<ast::ASTNode> parseFunctionConditional();
-        std::unique_ptr<ast::ASTNode> parseFunctionMatch();
+        std::vector<std::unique_ptr<ast::ASTNode>> parseStatementBody(const std::function<std::unique_ptr<ast::ASTNode>()> &memberParser);
         std::unique_ptr<ast::ASTNode> parseFunctionWhileLoop();
         std::unique_ptr<ast::ASTNode> parseFunctionForLoop();
 


### PR DESCRIPTION
For an example of the syntax:

```rust
#pragma endian big

struct Test {
    u32 value;
    match (value) {
        (0x1C ... 0x2C | 0x3C ... 0x4C): u32 thing;
    }
};

Test test @ 0;
```

Note that this does prevent using a bitwise or in the upper bound of a range, but considering that the lower bound wasn't allowed to use a bitwise or, it seems more consistent now.