### PR TITLE
Fix assignment of patterns to local variables

### DIFF
--- a/lib/include/pl/patterns/pattern_array_dynamic.hpp
+++ b/lib/include/pl/patterns/pattern_array_dynamic.hpp
@@ -45,8 +45,10 @@ namespace pl::ptrn {
         }
 
         void setOffset(u64 offset) override {
-            for (auto &entry : this->m_entries)
-                entry->setOffset(entry->getOffset() - this->getOffset() + offset);
+            for (auto &entry : this->m_entries) {
+                if (entry->getSection() == this->getSection())
+                    entry->setOffset(entry->getOffset() - this->getOffset() + offset);
+            }
 
             Pattern::setOffset(offset);
         }

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -48,8 +48,10 @@ namespace pl::ptrn {
         }
 
         void setOffset(u64 offset) override {
-            for (auto &member : this->m_members)
-                member->setOffset(member->getOffset() - this->getOffset() + offset);
+            for (auto &member : this->m_members) {
+                if (member->getSection() == this->getSection())
+                    member->setOffset(member->getOffset() - this->getOffset() + offset);
+            }
 
             Pattern::setOffset(offset);
         }

--- a/lib/include/pl/patterns/pattern_union.hpp
+++ b/lib/include/pl/patterns/pattern_union.hpp
@@ -48,8 +48,10 @@ namespace pl::ptrn {
         }
 
         void setOffset(u64 offset) override {
-            for (auto &member : this->m_members)
-                member->setOffset(member->getOffset() - this->getOffset() + offset);
+            for (auto &member : this->m_members) {
+                if (member->getSection() == this->getSection())
+                    member->setOffset(member->getOffset() - this->getOffset() + offset);
+            }
 
             Pattern::setOffset(offset);
         }


### PR DESCRIPTION
This causes an error to be thrown if an attempting to assign an incompatible type to a variable.

Non-reference variables will also now copy the data of the pattern into local storage which prevents local pattern variables from being displayed in the pattern data view.