### PR TITLE
Implement signed, enum, and boolean bitfield fields

### DIFF
--- a/lib/include/pl/core/ast/ast_node_array_variable_decl.hpp
+++ b/lib/include/pl/core/ast/ast_node_array_variable_decl.hpp
@@ -262,6 +262,8 @@ namespace pl::core::ast {
                 outputPattern->setEndian(templatePattern->getEndian());
             outputPattern->setTypeName(templatePattern->getTypeName());
             outputPattern->setSize(templatePattern->getSize() * entryCount);
+            if (evaluator->readOrderIsReversed())
+                outputPattern->setAbsoluteOffset(evaluator->getReadOffset());
             outputPattern->setSection(templatePattern->getSection());
 
             evaluator->setReadOffset(startOffset + outputPattern->getSize());

--- a/lib/include/pl/core/ast/ast_node_array_variable_decl.hpp
+++ b/lib/include/pl/core/ast/ast_node_array_variable_decl.hpp
@@ -46,7 +46,7 @@ namespace pl::core::ast {
         [[nodiscard]] std::vector<std::shared_ptr<ptrn::Pattern>> createPatterns(Evaluator *evaluator) const override {
             evaluator->updateRuntime(this);
 
-            auto startOffset = evaluator->dataOffset();
+            auto startOffset = evaluator->getBitwiseReadOffset();
 
             auto scopeGuard = SCOPE_GUARD {
                 evaluator->popSectionId();
@@ -69,11 +69,11 @@ namespace pl::core::ast {
                 if (offset == nullptr)
                     err::E0010.throwError("Cannot use void expression as placement offset.", {}, this);
 
-                evaluator->dataOffset() = std::visit(wolv::util::overloaded {
+                evaluator->setReadOffset(std::visit(wolv::util::overloaded {
                     [this](const std::string &) -> u64 { err::E0005.throwError("Cannot use string as placement offset.", "Try using a integral value instead.", this); },
                     [this](ptrn::Pattern *) -> u64 { err::E0005.throwError("Cannot use string as placement offset.", "Try using a integral value instead.", this); },
                     [](auto &&offset) -> u64 { return offset; }
-                }, offset->getValue());
+                }, offset->getValue()));
             }
 
             auto type = this->m_type->evaluate(evaluator);
@@ -97,11 +97,11 @@ namespace pl::core::ast {
             applyVariableAttributes(evaluator, this, pattern);
 
             if (this->m_placementOffset != nullptr && !evaluator->isGlobalScope()) {
-                evaluator->dataOffset() = startOffset;
+                evaluator->setBitwiseReadOffset(startOffset);
             }
 
             if (evaluator->getSectionId() == ptrn::Pattern::PatternLocalSectionId) {
-                evaluator->dataOffset() = startOffset;
+                evaluator->setBitwiseReadOffset(startOffset);
                 this->execute(evaluator);
                 return { };
             } else {
@@ -180,7 +180,8 @@ namespace pl::core::ast {
         bool m_constant;
 
         std::unique_ptr<ptrn::Pattern> createStaticArray(Evaluator *evaluator) const {
-            u64 startOffset = evaluator->dataOffset();
+            evaluator->alignToByte();
+            auto startOffset = evaluator->getReadOffset();
 
             auto templatePatterns = this->m_type->createPatterns(evaluator);
             if (templatePatterns.empty())
@@ -190,7 +191,7 @@ namespace pl::core::ast {
 
             templatePattern->setSection(evaluator->getSectionId());
 
-            evaluator->dataOffset() = startOffset;
+            evaluator->setReadOffset(startOffset);
 
             i128 entryCount = 0;
 
@@ -206,12 +207,12 @@ namespace pl::core::ast {
                 } else if (auto whileStatement = dynamic_cast<ASTNodeWhileStatement *>(sizeNode.get())) {
                     while (whileStatement->evaluateCondition(evaluator)) {
                         if (templatePattern->getSection() == ptrn::Pattern::MainSectionId)
-                            if ((evaluator->dataOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
+                            if ((evaluator->getReadOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
                                 err::E0004.throwError("Array expanded past end of the data before termination condition was met.", { }, this);
 
                         evaluator->handleAbort();
                         entryCount++;
-                        evaluator->dataOffset() += templatePattern->getSize();
+                        evaluator->getReadOffsetAndIncrement(templatePattern->getSize());
                     }
                 }
 
@@ -221,11 +222,11 @@ namespace pl::core::ast {
                 std::vector<u8> buffer(templatePattern->getSize());
                 while (true) {
                     if (templatePattern->getSection() == ptrn::Pattern::MainSectionId)
-                        if ((evaluator->dataOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
+                        if ((evaluator->getReadOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
                             err::E0004.throwError("Array expanded past end of the data before a null-entry was found.", "Try using a while-sized array instead to limit the size of the array.", this);
 
-                    evaluator->readData(evaluator->dataOffset(), buffer.data(), buffer.size(), templatePattern->getSection());
-                    evaluator->dataOffset() += buffer.size();
+                    evaluator->readData(evaluator->getReadOffset(), buffer.data(), buffer.size(), templatePattern->getSection());
+                    evaluator->getReadOffsetAndIncrement(buffer.size());
 
                     entryCount++;
 
@@ -263,10 +264,10 @@ namespace pl::core::ast {
             outputPattern->setSize(templatePattern->getSize() * entryCount);
             outputPattern->setSection(templatePattern->getSection());
 
-            evaluator->dataOffset() = startOffset + outputPattern->getSize();
+            evaluator->setReadOffset(startOffset + outputPattern->getSize());
 
             if (outputPattern->getSection() == ptrn::Pattern::MainSectionId)
-                if ((evaluator->dataOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
+                if ((evaluator->getReadOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
                     err::E0004.throwError("Array expanded past end of the data.", { }, this);
 
             return outputPattern;
@@ -281,7 +282,8 @@ namespace pl::core::ast {
                     evaluator->clearCurrentArrayIndex();
             };
 
-            auto arrayPattern = std::make_unique<ptrn::PatternArrayDynamic>(evaluator, evaluator->dataOffset(), 0);
+            evaluator->alignToByte();
+            auto arrayPattern = std::make_unique<ptrn::PatternArrayDynamic>(evaluator, evaluator->getReadOffset(), 0);
             arrayPattern->setVariableName(this->m_name);
             arrayPattern->setSection(evaluator->getSectionId());
 
@@ -336,8 +338,8 @@ namespace pl::core::ast {
                         size_t patternCount = patterns.size();
 
                         if (arrayPattern->getSection() == ptrn::Pattern::MainSectionId)
-                            if ((evaluator->dataOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
-                                err::E0004.throwError("Array expanded past end of the data.", fmt::format("Entry {} exceeded data by {} bytes.", i, evaluator->dataOffset() - evaluator->getDataSize()), this);
+                            if ((evaluator->getReadOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
+                                err::E0004.throwError("Array expanded past end of the data.", fmt::format("Entry {} exceeded data by {} bytes.", i, evaluator->getReadOffset() - evaluator->getDataSize()), this);
 
                         if (!patterns.empty())
                             addEntries(std::move(patterns));
@@ -366,7 +368,7 @@ namespace pl::core::ast {
                         size_t patternCount = patterns.size();
 
                         if (arrayPattern->getSection() == ptrn::Pattern::MainSectionId)
-                            if ((evaluator->dataOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
+                            if ((evaluator->getReadOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
                                 err::E0004.throwError("Array expanded past end of the data before termination condition was met.", { }, this);
 
                         if (!patterns.empty())
@@ -400,11 +402,11 @@ namespace pl::core::ast {
                         std::vector<u8> buffer(pattern->getSize());
 
                         if (arrayPattern->getSection() == ptrn::Pattern::MainSectionId)
-                            if ((evaluator->dataOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
+                            if ((evaluator->getReadOffset() - evaluator->getDataBaseAddress()) > (evaluator->getDataSize() + 1))
                                 err::E0004.throwError("Array expanded past end of the data before a null-entry was found.", "Try using a while-sized array instead to limit the size of the array.", this);
 
                         const auto patternSize = pattern->getSize();
-                        evaluator->readData(evaluator->dataOffset() - patternSize, buffer.data(), buffer.size(), pattern->getSection());
+                        evaluator->readData(evaluator->getReadOffset() - patternSize, buffer.data(), buffer.size(), pattern->getSection());
 
                         addEntries(hlp::moveToVector(std::move(pattern)));
 

--- a/lib/include/pl/core/ast/ast_node_bitfield_array_variable_decl.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield_array_variable_decl.hpp
@@ -183,9 +183,14 @@ namespace pl::core::ast {
             auto endPosition = evaluator->getBitwiseReadOffset();
             auto startOffset = (initialPosition.byteOffset * 8) + initialPosition.bitOffset;
             auto endOffset = (endPosition.byteOffset * 8) + endPosition.bitOffset;
-            auto totalBitSize = startOffset > endOffset ? startOffset - endOffset : endOffset - startOffset;
 
-            arrayPattern->setBitSize(totalBitSize);
+            if (startOffset < endOffset) {
+                arrayPattern->setBitSize(endOffset - startOffset);
+            } else {
+                arrayPattern->setAbsoluteOffset(endPosition.byteOffset);
+                arrayPattern->setBitOffset(endPosition.bitOffset);
+                arrayPattern->setBitSize(startOffset - endOffset);
+            }
 
             for (auto &pattern : entries) {
                 if (auto bitfieldMember = dynamic_cast<ptrn::PatternBitfieldMember*>(pattern.get()); bitfieldMember != nullptr)

--- a/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
@@ -40,8 +40,8 @@ namespace pl::core::ast {
                 err::E0010.throwError("Cannot use void expression as bitfield field size.", {}, this);
 
             u8 bitSize = std::visit(wolv::util::overloaded {
-                    [this](const std::string &) -> u8 { err::E0005.throwError("Cannot use string as bitfield field size.", "Try using a integral value instead.", this); },
-                    [this](ptrn::Pattern *) -> u8 { err::E0005.throwError("Cannot use string as bitfield field size.", "Try using a integral value instead.", this); },
+                    [this](const std::string &) -> u8 { err::E0005.throwError("Cannot use string as bitfield field size.", "Try using a integral value instead.", this->m_size.get()); },
+                    [this](ptrn::Pattern *) -> u8 { err::E0005.throwError("Cannot use string as bitfield field size.", "Try using a integral value instead.", this->m_size.get()); },
                     [](auto &&offset) -> u8 { return static_cast<u8>(offset); }
             }, literal->getValue());
 

--- a/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
@@ -100,8 +100,10 @@ namespace pl::core::ast {
                 bitfieldEnum->setTypeName(patternEnum->getTypeName());
                 bitfieldEnum->setEnumValues(patternEnum->getEnumValues());
                 result = std::move(bitfieldEnum);
+            } else if (dynamic_cast<ptrn::PatternBoolean*>(pattern.get()) != nullptr) {
+                result = std::make_shared<ptrn::PatternBitfieldFieldBoolean>(evaluator, byteOffset, bitOffset, bitSize);
             } else {
-                err::E0004.throwError("Can only use enums as sized bitfield fields.", {}, this);
+                err::E0004.throwError("Can only use enums or bools as sized bitfield fields.", {}, this);
             }
             return result;
         }

--- a/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
@@ -46,13 +46,8 @@ namespace pl::core::ast {
             }, literal->getValue());
 
             std::shared_ptr<ptrn::PatternBitfieldField> pattern;
-            if (evaluator->isBitfieldReversed()) {
-                evaluator->incrementBitfieldBitOffset(-bitSize);
-                pattern = this->createBitfield(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), bitSize);
-            } else {
-                pattern = this->createBitfield(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), bitSize);
-                evaluator->incrementBitfieldBitOffset(bitSize);
-            }
+            auto position = evaluator->getBitwiseReadOffsetAndIncrement(bitSize);
+            pattern = this->createBitfield(evaluator, position.byteOffset, position.bitOffset, bitSize);
             pattern->setPadding(this->isPadding());
             pattern->setVariableName(this->getName());
 

--- a/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
+++ b/lib/include/pl/core/ast/ast_node_bitfield_field.hpp
@@ -27,6 +27,10 @@ namespace pl::core::ast {
 
         [[nodiscard]] bool isPadding() const { return this->getName() == "$padding$"; }
 
+        [[nodiscard]] virtual std::shared_ptr<ptrn::PatternBitfieldField> createBitfield(Evaluator *evaluator, u64 byteOffset, u8 bitOffset, u8 bitSize) const {
+            return std::make_shared<ptrn::PatternBitfieldField>(evaluator, byteOffset, bitOffset, bitSize);
+        }
+
         [[nodiscard]] std::vector<std::shared_ptr<ptrn::Pattern>> createPatterns(Evaluator *evaluator) const override {
             evaluator->updateRuntime(this);
 
@@ -44,9 +48,9 @@ namespace pl::core::ast {
             std::shared_ptr<ptrn::PatternBitfieldField> pattern;
             if (evaluator->isBitfieldReversed()) {
                 evaluator->incrementBitfieldBitOffset(-bitSize);
-                pattern = std::make_shared<ptrn::PatternBitfieldField>(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), bitSize);
+                pattern = this->createBitfield(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), bitSize);
             } else {
-                pattern = std::make_shared<ptrn::PatternBitfieldField>(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), bitSize);
+                pattern = this->createBitfield(evaluator, evaluator->dataOffset(), evaluator->getBitfieldBitOffset(), bitSize);
                 evaluator->incrementBitfieldBitOffset(bitSize);
             }
             pattern->setPadding(this->isPadding());
@@ -63,6 +67,15 @@ namespace pl::core::ast {
     private:
         std::string m_name;
         std::unique_ptr<ASTNode> m_size;
+    };
+
+    class ASTNodeBitfieldFieldSigned : public ASTNodeBitfieldField {
+    public:
+        using ASTNodeBitfieldField::ASTNodeBitfieldField;
+
+        [[nodiscard]] std::shared_ptr<ptrn::PatternBitfieldField> createBitfield(Evaluator *evaluator, u64 byteOffset, u8 bitOffset, u8 bitSize) const override {
+            return std::make_shared<ptrn::PatternBitfieldFieldSigned>(evaluator, byteOffset, bitOffset, bitSize);
+        }
     };
 
 }

--- a/lib/include/pl/core/ast/ast_node_builtin_type.hpp
+++ b/lib/include/pl/core/ast/ast_node_builtin_type.hpp
@@ -27,10 +27,8 @@ namespace pl::core::ast {
         [[nodiscard]] std::vector<std::shared_ptr<ptrn::Pattern>> createPatterns(Evaluator *evaluator) const override {
             evaluator->updateRuntime(this);
 
-            auto offset = evaluator->dataOffset();
             auto size   = Token::getTypeSize(this->m_type);
-
-            evaluator->dataOffset() += size;
+            auto offset = evaluator->getReadOffsetAndIncrement(size);
 
             std::unique_ptr<ptrn::Pattern> pattern;
             if (Token::isUnsigned(this->m_type))

--- a/lib/include/pl/core/ast/ast_node_cast.hpp
+++ b/lib/include/pl/core/ast/ast_node_cast.hpp
@@ -36,8 +36,8 @@ namespace pl::core::ast {
         [[nodiscard]] std::unique_ptr<ASTNode> evaluate(Evaluator *evaluator) const override {
             evaluator->updateRuntime(this);
 
-            auto startOffset = evaluator->dataOffset();
-            ON_SCOPE_EXIT { evaluator->dataOffset() = startOffset; };
+            auto startOffset = evaluator->getBitwiseReadOffset();
+            ON_SCOPE_EXIT { evaluator->setBitwiseReadOffset(startOffset); };
 
             auto evaluatedValue = this->m_value->evaluate(evaluator);
             auto evaluatedType  = this->m_type->evaluate(evaluator);

--- a/lib/include/pl/core/ast/ast_node_enum.hpp
+++ b/lib/include/pl/core/ast/ast_node_enum.hpp
@@ -27,7 +27,13 @@ namespace pl::core::ast {
             evaluator->updateRuntime(this);
 
             evaluator->alignToByte();
-            auto pattern = std::make_shared<ptrn::PatternEnum>(evaluator, evaluator->getReadOffset(), 0);
+
+            const auto nodes = this->m_underlyingType->createPatterns(evaluator);
+            if (nodes.empty())
+                err::E0005.throwError("'auto' can only be used with parameters.", { }, this);
+            auto &underlying = nodes.front();
+
+            auto pattern = std::make_shared<ptrn::PatternEnum>(evaluator, underlying->getOffset(), 0);
 
             pattern->setSection(evaluator->getSectionId());
 
@@ -56,11 +62,6 @@ namespace pl::core::ast {
             }
 
             pattern->setEnumValues(enumEntries);
-
-            const auto nodes = this->m_underlyingType->createPatterns(evaluator);
-            if (nodes.empty())
-                err::E0005.throwError("'auto' can only be used with parameters.", { }, this);
-            auto &underlying = nodes.front();
 
             pattern->setSize(underlying->getSize());
             pattern->setEndian(underlying->getEndian());

--- a/lib/include/pl/core/ast/ast_node_enum.hpp
+++ b/lib/include/pl/core/ast/ast_node_enum.hpp
@@ -26,7 +26,8 @@ namespace pl::core::ast {
         [[nodiscard]] std::vector<std::shared_ptr<ptrn::Pattern>> createPatterns(Evaluator *evaluator) const override {
             evaluator->updateRuntime(this);
 
-            auto pattern = std::make_shared<ptrn::PatternEnum>(evaluator, evaluator->dataOffset(), 0);
+            evaluator->alignToByte();
+            auto pattern = std::make_shared<ptrn::PatternEnum>(evaluator, evaluator->getReadOffset(), 0);
 
             pattern->setSection(evaluator->getSectionId());
 

--- a/lib/include/pl/core/ast/ast_node_function_call.hpp
+++ b/lib/include/pl/core/ast/ast_node_function_call.hpp
@@ -44,9 +44,9 @@ namespace pl::core::ast {
 
             evaluator->pushSectionId(ptrn::Pattern::HeapSectionId);
 
-            auto startOffset = evaluator->dataOffset();
+            auto startOffset = evaluator->getBitwiseReadOffset();
             ON_SCOPE_EXIT {
-                evaluator->dataOffset() = startOffset;
+                evaluator->setBitwiseReadOffset(startOffset);
                 evaluator->popSectionId();
             };
 

--- a/lib/include/pl/core/ast/ast_node_function_definition.hpp
+++ b/lib/include/pl/core/ast/ast_node_function_definition.hpp
@@ -71,12 +71,12 @@ namespace pl::core::ast {
             evaluator->addCustomFunction(this->m_name, paramCount, evaluatedDefaultParams, [this](Evaluator *ctx, const std::vector<Token::Literal> &params) -> std::optional<Token::Literal> {
                 std::vector<std::shared_ptr<ptrn::Pattern>> variables;
 
-                auto startOffset = ctx->dataOffset();
+                auto startOffset = ctx->getBitwiseReadOffset();
                 ctx->pushScope(nullptr, variables);
                 ctx->pushSectionId(ptrn::Pattern::HeapSectionId);
                 ON_SCOPE_EXIT {
                     ctx->popScope();
-                    ctx->dataOffset() = startOffset;
+                    ctx->setBitwiseReadOffset(startOffset);
                     ctx->popSectionId();
                 };
 

--- a/lib/include/pl/core/ast/ast_node_lvalue_assignment.hpp
+++ b/lib/include/pl/core/ast/ast_node_lvalue_assignment.hpp
@@ -53,7 +53,7 @@ namespace pl::core::ast {
 
 
             if (this->getLValueName() == "$")
-                evaluator->dataOffset() = literal->getValue().toUnsigned();
+                evaluator->setReadOffset(literal->getValue().toUnsigned());
             else
                 evaluator->setVariable(this->getLValueName(), literal->getValue());
 

--- a/lib/include/pl/core/ast/ast_node_rvalue.hpp
+++ b/lib/include/pl/core/ast/ast_node_rvalue.hpp
@@ -122,8 +122,10 @@ namespace pl::core::ast {
                 std::string value;
                 readVariable(evaluator, value, pattern);
                 literal = value;
+            } else if (auto bitfieldFieldPatternSigned = dynamic_cast<ptrn::PatternBitfieldFieldSigned *>(pattern); bitfieldFieldPatternSigned != nullptr) {
+                literal = hlp::signExtend(bitfieldFieldPatternSigned->getBitSize(), bitfieldFieldPatternSigned->readValue());
             } else if (auto bitfieldFieldPattern = dynamic_cast<ptrn::PatternBitfieldField *>(pattern); bitfieldFieldPattern != nullptr) {
-                literal = u128(bitfieldFieldPattern->readValue());
+                literal = bitfieldFieldPattern->readValue();
             } else {
                 literal = pattern;
             }

--- a/lib/include/pl/core/ast/ast_node_rvalue.hpp
+++ b/lib/include/pl/core/ast/ast_node_rvalue.hpp
@@ -52,7 +52,7 @@ namespace pl::core::ast {
 
             if (this->getPath().size() == 1) {
                 if (auto name = std::get_if<std::string>(&this->getPath().front()); name != nullptr) {
-                    if (*name == "$") return std::unique_ptr<ASTNode>(new ASTNodeLiteral(u128(evaluator->dataOffset())));
+                    if (*name == "$") return std::unique_ptr<ASTNode>(new ASTNodeLiteral(u128(evaluator->getReadOffset())));
                     else if (*name == "null") return std::unique_ptr<ASTNode>(new ASTNodeLiteral(new ptrn::PatternPadding(evaluator, 0, 0)));
 
                     auto parameterPack = evaluator->getScope(0).parameterPack;

--- a/lib/include/pl/core/ast/ast_node_rvalue.hpp
+++ b/lib/include/pl/core/ast/ast_node_rvalue.hpp
@@ -122,6 +122,8 @@ namespace pl::core::ast {
                 std::string value;
                 readVariable(evaluator, value, pattern);
                 literal = value;
+            } else if (auto bitfieldFieldPatternBoolean = dynamic_cast<ptrn::PatternBitfieldFieldBoolean *>(pattern); bitfieldFieldPatternBoolean != nullptr) {
+                literal = bool(bitfieldFieldPatternBoolean->readValue());
             } else if (auto bitfieldFieldPatternSigned = dynamic_cast<ptrn::PatternBitfieldFieldSigned *>(pattern); bitfieldFieldPatternSigned != nullptr) {
                 literal = hlp::signExtend(bitfieldFieldPatternSigned->getBitSize(), bitfieldFieldPatternSigned->readValue());
             } else if (auto bitfieldFieldPattern = dynamic_cast<ptrn::PatternBitfieldField *>(pattern); bitfieldFieldPattern != nullptr) {

--- a/lib/include/pl/core/ast/ast_node_struct.hpp
+++ b/lib/include/pl/core/ast/ast_node_struct.hpp
@@ -40,6 +40,11 @@ namespace pl::core::ast {
                 evaluator->alignToByte();
             };
 
+            auto setSize = [&]() {
+                auto currentOffset = evaluator->getReadOffset();
+                pattern->setSize(currentOffset > startOffset ? currentOffset - startOffset : startOffset - currentOffset);
+            };
+
             for (auto &inheritance : this->m_inheritance) {
                 if (evaluator->getCurrentControlFlowStatement() != ControlFlowStatement::None)
                     break;
@@ -51,7 +56,7 @@ namespace pl::core::ast {
                     for (auto &member : structPattern->getEntries()) {
                         memberPatterns.push_back(member);
                     }
-                    pattern->setSize(evaluator->getReadOffset() - startOffset);
+                    setSize();
                 }
             }
 
@@ -61,7 +66,7 @@ namespace pl::core::ast {
                     memberPattern->setSection(evaluator->getSectionId());
                     memberPatterns.push_back(std::move(memberPattern));
                 }
-                pattern->setSize(evaluator->getReadOffset() - startOffset);
+                setSize();
 
                 if (!evaluator->getCurrentArrayIndex().has_value()) {
                     if (evaluator->getCurrentControlFlowStatement() == ControlFlowStatement::Return)
@@ -79,6 +84,9 @@ namespace pl::core::ast {
             }
 
             pattern->setMembers(memberPatterns);
+
+            if (evaluator->readOrderIsReversed())
+                pattern->setAbsoluteOffset(evaluator->getReadOffset());
 
             applyTypeAttributes(evaluator, this, pattern);
 

--- a/lib/include/pl/core/ast/ast_node_type_operator.hpp
+++ b/lib/include/pl/core/ast/ast_node_type_operator.hpp
@@ -45,10 +45,10 @@ namespace pl::core::ast {
                         err::E0001.throwError("Invalid type operation.", {}, this);
                 }
             } else {
-                auto offset = evaluator->dataOffset();
+                auto offset = evaluator->getBitwiseReadOffset();
                 evaluator->pushSectionId(ptrn::Pattern::InstantiationSectionId);
                 ON_SCOPE_EXIT {
-                    evaluator->dataOffset() = offset;
+                    evaluator->setBitwiseReadOffset(offset);
                     evaluator->popSectionId();
                 };
 

--- a/lib/include/pl/core/ast/ast_node_union.hpp
+++ b/lib/include/pl/core/ast/ast_node_union.hpp
@@ -64,6 +64,8 @@ namespace pl::core::ast {
             }
 
             evaluator->setReadOffset(startOffset + size);
+            if (evaluator->readOrderIsReversed())
+                pattern->setAbsoluteOffset(evaluator->getReadOffset());
             pattern->setMembers(memberPatterns);
 
             applyTypeAttributes(evaluator, this, pattern);

--- a/lib/include/pl/core/token.hpp
+++ b/lib/include/pl/core/token.hpp
@@ -41,6 +41,8 @@ namespace pl::core {
             Using,
             Enum,
             Bitfield,
+            Unsigned,
+            Signed,
             LittleEndian,
             BigEndian,
             If,
@@ -241,6 +243,8 @@ namespace pl::core {
             const auto Union        = createToken(core::Token::Type::Keyword, Token::Keyword::Union);
             const auto Function     = createToken(core::Token::Type::Keyword, Token::Keyword::Function);
             const auto Bitfield     = createToken(core::Token::Type::Keyword, Token::Keyword::Bitfield);
+            const auto Unsigned     = createToken(core::Token::Type::Keyword, Token::Keyword::Unsigned);
+            const auto Signed       = createToken(core::Token::Type::Keyword, Token::Keyword::Signed);
             const auto LittleEndian = createToken(core::Token::Type::Keyword, Token::Keyword::LittleEndian);
             const auto BigEndian    = createToken(core::Token::Type::Keyword, Token::Keyword::BigEndian);
             const auto Parent       = createToken(core::Token::Type::Keyword, Token::Keyword::Parent);

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -91,7 +91,7 @@ namespace pl::ptrn {
         [[nodiscard]] u64 getOffset() const { return this->m_offset; }
         [[nodiscard]] virtual u128 getOffsetForSorting() const { return this->getOffset() << 3; }
         [[nodiscard]] u32 getHeapAddress() const { return this->getOffset() >> 32; }
-        virtual void setOffset(u64 offset) {
+        void setAbsoluteOffset(u64 offset) {
             if (this->m_offset != offset) {
                 if (this->m_evaluator)
                     this->m_evaluator->patternDestroyed(this);
@@ -99,6 +99,9 @@ namespace pl::ptrn {
                 if (this->m_evaluator)
                     this->m_evaluator->patternCreated(this);
             }
+        }
+        virtual void setOffset(u64 offset) {
+            setAbsoluteOffset(offset);
         }
 
         [[nodiscard]] size_t getSize() const { return this->m_size; }

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -89,7 +89,7 @@ namespace pl::ptrn {
         virtual std::unique_ptr<Pattern> clone() const = 0;
 
         [[nodiscard]] u64 getOffset() const { return this->m_offset; }
-        [[nodiscard]] virtual u64 getOffsetForSorting() const { return this->getOffset(); }
+        [[nodiscard]] virtual u128 getOffsetForSorting() const { return this->getOffset() << 3; }
         [[nodiscard]] u32 getHeapAddress() const { return this->getOffset() >> 32; }
         virtual void setOffset(u64 offset) {
             if (this->m_offset != offset) {
@@ -102,7 +102,7 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] size_t getSize() const { return this->m_size; }
-        [[nodiscard]] virtual size_t getSizeForSorting() const { return this->getSize(); }
+        [[nodiscard]] virtual u128 getSizeForSorting() const { return this->getSize() << 3; }
         void setSize(size_t size) { this->m_size = size; }
 
         [[nodiscard]] std::string getVariableName() const {
@@ -198,15 +198,14 @@ namespace pl::ptrn {
                 return *this->m_cachedDisplayValue;
 
             try {
-                auto &currOffset = this->m_evaluator->dataOffset();
-                auto startOffset = currOffset;
-                currOffset = this->getOffset();
+                auto startOffset = this->m_evaluator->getReadOffset();
+                this->m_evaluator->setReadOffset(this->getOffset());
 
                 auto savedScope = this->m_evaluator->getScope(0);
 
                 ON_SCOPE_EXIT {
                     this->m_evaluator->getScope(0) = savedScope;
-                    currOffset = startOffset;
+                    this->m_evaluator->setReadOffset(startOffset);
                 };
 
                 return this->formatDisplayValue();

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -150,6 +150,36 @@ namespace pl::ptrn {
         }
     };
 
+    class PatternBitfieldFieldBoolean : public PatternBitfieldField {
+    public:
+        using PatternBitfieldField::PatternBitfieldField;
+
+        [[nodiscard]] std::unique_ptr<Pattern> clone() const override {
+            return std::unique_ptr<Pattern>(new PatternBitfieldFieldBoolean(*this));
+        }
+
+        [[nodiscard]] core::Token::Literal getValue() const override {
+            return transformValue(this->readValue());
+        }
+
+        [[nodiscard]] std::string getFormattedName() const override {
+            return "bool";
+        }
+
+        std::string formatDisplayValue() override {
+            switch (this->getValue().toUnsigned()) {
+                case 0: return "false";
+                case 1: return "true";
+                default: return "true*";
+            }
+        }
+
+        [[nodiscard]] std::string toString() const override {
+            auto value = this->getValue();
+            return Pattern::formatDisplayValue(fmt::format("{}", value.toBoolean() ? "true" : "false"), value);
+        }
+    };
+
     class PatternBitfieldFieldEnum : public PatternBitfieldField {
     public:
         using PatternBitfieldField::PatternBitfieldField;

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -39,13 +39,9 @@ namespace pl::ptrn {
 
         virtual void setReversed(bool reversed) { wolv::util::unused(reversed); }
 
-        [[nodiscard]] u64 getOffsetForSorting() const override {
-            // If this member has no parent, that means we are sorting in a byte-based context.
+        [[nodiscard]] u128 getOffsetForSorting() const override {
             auto *parent = this->getParentBitfield();
-            if (parent == nullptr)
-                return getOffset();
-
-            if (parent->isReversed()) {
+            if (parent != nullptr && parent->isReversed()) {
                 auto parentOffset = parent->getTotalBitOffset();
                 auto parentSize = parent->getBitSize();
                 return parentOffset + parentSize - ((this->getTotalBitOffset() - parentOffset) + this->getBitSize());
@@ -54,11 +50,7 @@ namespace pl::ptrn {
             return this->getTotalBitOffset();
         }
 
-        [[nodiscard]] size_t getSizeForSorting() const override {
-            // If this member has no parent, that means we are sorting in a byte-based context.
-            if (this->getParentBitfield() == nullptr)
-                return this->getSize();
-
+        [[nodiscard]] u128 getSizeForSorting() const override {
             return this->getBitSize();
         }
     };

--- a/lib/include/pl/patterns/pattern_enum.hpp
+++ b/lib/include/pl/patterns/pattern_enum.hpp
@@ -71,13 +71,11 @@ namespace pl::ptrn {
             return fmt::format("{} (0x{:0{}X})", this->toString(), value, this->getSize() * 2);
         }
 
-        [[nodiscard]] std::string toString() const override {
-            u128 value = this->getValue().toUnsigned();
-
-            std::string result = this->getTypeName() + "::";
+        static std::string getEnumName(const std::string &typeName, u128 value, const std::vector<EnumValue> &enumValues) {
+            std::string result = typeName + "::";
 
             bool foundValue = false;
-            for (auto &[min, max, name] : this->getEnumValues()) {
+            for (const auto &[min, max, name] : enumValues) {
                 if (value >= min.toUnsigned() && value <= max.toUnsigned()) {
                     result += name;
                     foundValue = true;
@@ -87,8 +85,12 @@ namespace pl::ptrn {
 
             if (!foundValue)
                 result += "???";
+            return result;
+        }
 
-            return Pattern::formatDisplayValue(result, this->clone().get());
+        [[nodiscard]] std::string toString() const override {
+            u128 value = this->getValue().toUnsigned();
+            return Pattern::formatDisplayValue(getEnumName(this->getTypeName(), value, this->m_enumValues), this->clone().get());
         }
 
     private:

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -50,11 +50,11 @@ namespace pl::core {
             }
         }
 
-        auto startOffset = this->dataOffset();
+        auto startOffset = this->getBitwiseReadOffset();
         auto typePatterns = type->createPatterns(this);
         auto typePattern = std::move(typePatterns.front());
 
-        this->dataOffset() = startOffset;
+        this->setBitwiseReadOffset(startOffset);
 
         auto pattern = new ptrn::PatternArrayDynamic(this, 0, typePattern->getSize() * entryCount);
 
@@ -112,7 +112,7 @@ namespace pl::core {
         }
 
         auto sectionId = this->getSectionId();
-        auto startOffset = this->dataOffset();
+        auto startOffset = this->getBitwiseReadOffset();
 
         auto heapAddress = u64(this->getHeap().size());
         u32 patternLocalAddress = 0;
@@ -133,7 +133,7 @@ namespace pl::core {
         auto typePattern = type->createPatterns(this);
         this->popSectionId();
 
-        this->dataOffset() = startOffset;
+        this->setBitwiseReadOffset(startOffset);
 
         if (typePattern.empty()) {
             // Handle auto variables
@@ -593,6 +593,9 @@ namespace pl::core {
     }
 
     bool Evaluator::evaluate(const std::string &sourceCode, const std::vector<std::shared_ptr<ast::ASTNode>> &ast) {
+        this->m_readOrderReversed = false;
+        this->m_currBitOffset = 0;
+
         this->m_sections.clear();
         this->m_sectionIdStack.clear();
         this->m_sectionId = 1;
@@ -610,9 +613,6 @@ namespace pl::core {
         this->m_colorIndex = 0;
         this->m_aborted = false;
         this->m_evaluated = false;
-
-        this->m_bitfieldIsReversed = false;
-        this->m_bitfieldBitOffset = 0;
 
         if (this->m_allowDangerousFunctions == DangerousFunctionPermission::Deny)
             this->m_allowDangerousFunctions = DangerousFunctionPermission::Ask;
@@ -645,7 +645,7 @@ namespace pl::core {
                     if (node == nullptr)
                         continue;
 
-                    auto startOffset = this->dataOffset();
+                    auto startOffset = this->getBitwiseReadOffset();
 
                     if (dynamic_cast<ast::ASTNodeTypeDecl *>(node) != nullptr) {
                         // Don't create patterns from type declarations
@@ -665,7 +665,7 @@ namespace pl::core {
                                 if (varDeclNode->isInVariable() && this->m_inVariables.contains(name))
                                     this->setVariable(name, this->m_inVariables[name]);
 
-                                this->dataOffset() = startOffset;
+                                this->setBitwiseReadOffset(startOffset);
                             } else {
                                 this->m_patterns.push_back(std::move(pattern));
                             }
@@ -686,7 +686,7 @@ namespace pl::core {
                             if (localVariable) {
                                 wolv::util::unused(arrayVarDeclNode->execute(this));
 
-                                this->dataOffset() = startOffset;
+                                this->setBitwiseReadOffset(startOffset);
                             } else {
                                 this->m_patterns.push_back(std::move(pattern));
                             }

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -486,6 +486,10 @@ namespace pl::core {
                         addToken(tkn::Keyword::Enum);
                     else if (identifier == "bitfield")
                         addToken(tkn::Keyword::Bitfield);
+                    else if (identifier == "unsigned")
+                        addToken(tkn::Keyword::Unsigned);
+                    else if (identifier == "signed")
+                        addToken(tkn::Keyword::Signed);
                     else if (identifier == "be")
                         addToken(tkn::Keyword::BigEndian);
                     else if (identifier == "le")

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -1352,7 +1352,11 @@ namespace pl::core {
                     err::P0002.throwError(fmt::format("Placement syntax is invalid within bitfields."), {}, 0);
 
                 auto variableName = getValue<Token::Identifier>(-1).get();
-                member = parseMemberVariable(std::move(type), false, false, variableName);
+
+                if (MATCHES(sequence(tkn::Operator::Colon)))
+                    member = create<ast::ASTNodeBitfieldFieldSizedType>(variableName, std::move(type), parseMathematicalExpression());
+                else
+                    member = parseMemberVariable(std::move(type), false, false, variableName);
             } else
                 err::P0002.throwError(fmt::format("Expected a variable name, got {}.", getFormattedToken(0)), {}, 0);
         } else if (MATCHES(sequence(tkn::Keyword::If)))

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -1327,14 +1327,6 @@ namespace pl::core {
                     if (type == nullptr)
                         err::P0002.throwError(fmt::format("Expected a variable name followed by ':', a function call or a bitfield type name, got '{}'.", name), {}, 1);
                     parseCustomTypeParameters(type);
-
-                    ast::ASTNodeTypeDecl *topmostTypeDecl = type.get();
-                    while (auto *parentTypeDecl = dynamic_cast<ast::ASTNodeTypeDecl*>(topmostTypeDecl->getType().get()))
-                        topmostTypeDecl = parentTypeDecl;
-                    if (auto *nestedBitfield = dynamic_cast<ast::ASTNodeBitfield*>(topmostTypeDecl->getType().get()); nestedBitfield != nullptr)
-                        nestedBitfield->setNested();
-                    else
-                        err::P0003.throwError("Only bitfields can be nested within other bitfields.", {}, 1);
                 }
             }
 

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -201,6 +201,8 @@ namespace pl::core {
                                       case Enum: return "enum";
                                       case Match: return "match";
                                       case Bitfield: return "bitfield";
+                                      case Unsigned: return "unsigned";
+                                      case Signed: return "signed";
                                       case LittleEndian: return "le";
                                       case BigEndian: return "be";
                                       case If: return "if";

--- a/lib/source/pl/lib/std/mem.cpp
+++ b/lib/source/pl/lib/std/mem.cpp
@@ -131,7 +131,7 @@ namespace pl::lib::libstd::mem {
             /* current_bit_offset() */
             runtime.addFunction(nsStdMem, "current_bit_offset", FunctionParameterCount::none(), [](Evaluator *ctx, auto params) -> std::optional<Token::Literal> {
                 wolv::util::unused(params);
-                return u128(ctx->getBitfieldBitOffset());
+                return u128(ctx->getBitwiseReadOffset().bitOffset);
             });
 
             /* read_bits(byteOffset, bitOffset, bitSize) */

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -121,7 +121,7 @@ namespace pl {
             this->m_currAST = std::move(ast.value());
         }
 
-        evaluator->dataOffset() = this->m_startAddress.value_or(evaluator->getDataBaseAddress());
+        evaluator->setReadOffset(this->m_startAddress.value_or(evaluator->getDataBaseAddress()));
 
 
         if (!evaluator->evaluate(code, this->m_currAST)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(AVAILABLE_TESTS
         SucceedingAssert
         FailingAssert
         Bitfields
+        ReversedBitfields
         Math
         RValues
         Namespaces

--- a/tests/include/test_patterns/test_pattern_bitfields.hpp
+++ b/tests/include/test_patterns/test_pattern_bitfields.hpp
@@ -100,4 +100,56 @@ namespace pl::test {
         }
     };
 
+    class TestPatternReversedBitfields : public TestPattern {
+    public:
+        TestPatternReversedBitfields() : TestPattern("ReversedBitfields") {
+            auto testBitfield = create<PatternBitfield>("Test", "test", 0x02, 0, 16);
+
+            std::vector<std::shared_ptr<Pattern>> bitfieldFields;
+            {
+                bitfieldFields.push_back(create<PatternBitfieldField>("", "flag0", 0x03, 7, 1, testBitfield.get()));
+                bitfieldFields.push_back(create<PatternBitfieldField>("", "flag1", 0x03, 6, 1, testBitfield.get()));
+                bitfieldFields.push_back(create<PatternBitfieldField>("", "flag2", 0x03, 5, 1, testBitfield.get()));
+                bitfieldFields.push_back(create<PatternBitfieldField>("", "flag3", 0x03, 4, 1, testBitfield.get()));
+                bitfieldFields.push_back(create<PatternBitfieldField>("", "flag4", 0x03, 3, 1, testBitfield.get()));
+                bitfieldFields.push_back(create<PatternBitfieldField>("", "flag5", 0x03, 2, 1, testBitfield.get()));
+                bitfieldFields.push_back(create<PatternBitfieldField>("", "enumerated", 0x02, 4, 6, testBitfield.get()));
+            }
+
+            testBitfield->setFields(std::move(bitfieldFields));
+            testBitfield->setEndian(std::endian::big);
+            testBitfield->setReversed(true);
+            testBitfield->addAttribute("bitfield_order", { 1, 16 });
+
+            addPattern(std::move(testBitfield));
+        }
+        ~TestPatternReversedBitfields() override = default;
+
+        [[nodiscard]] std::string getSourceCode() const override {
+            return R"(
+                #pragma endian big
+
+                bitfield Test {
+                    flag0 : 1;
+                    flag1 : 1;
+                    flag2 : 1;
+                    flag3 : 1;
+                    flag4 : 1;
+                    flag5 : 1;
+                    enumerated : 6;
+                } [[bitfield_order(1, 16)]];
+
+                Test test @ 2;
+
+                std::assert(test.flag0 == 1, "flag0 was invalid");
+                std::assert(test.flag1 == 1, "flag1 was invalid");
+                std::assert(test.flag2 == 1, "flag2 was invalid");
+                std::assert(test.flag3 == 0, "flag3 was invalid");
+                std::assert(test.flag4 == 0, "flag4 was invalid");
+                std::assert(test.flag5 == 0, "flag5 was invalid");
+                std::assert(test.enumerated == 0x39, "enumerated was invalid");
+            )";
+        }
+    };
+
 }

--- a/tests/include/test_patterns/test_pattern_bitfields.hpp
+++ b/tests/include/test_patterns/test_pattern_bitfields.hpp
@@ -141,23 +141,23 @@ namespace pl::test {
                 };
 
                 bitfield Test {
-                    flag0 : 1;
-                    flag1 : 1;
-                    flag2 : 1;
-                    flag3 : 1;
-                    flag4 : 1;
-                    flag5 : 1;
+                    bool flag0 : 1;
+                    bool flag1 : 1;
+                    bool flag2 : 1;
+                    bool flag3 : 1;
+                    bool flag4 : 1;
+                    bool flag5 : 1;
                     Enum enumerated : 6;
                 } [[bitfield_order(1, 16)]];
 
                 Test test @ 2;
 
-                std::assert(test.flag0 == 1, "flag0 was invalid");
-                std::assert(test.flag1 == 1, "flag1 was invalid");
-                std::assert(test.flag2 == 1, "flag2 was invalid");
-                std::assert(test.flag3 == 0, "flag3 was invalid");
-                std::assert(test.flag4 == 0, "flag4 was invalid");
-                std::assert(test.flag5 == 0, "flag5 was invalid");
+                std::assert(test.flag0 == true, "flag0 was invalid");
+                std::assert(test.flag1 == true, "flag1 was invalid");
+                std::assert(test.flag2 == true, "flag2 was invalid");
+                std::assert(test.flag3 == false, "flag3 was invalid");
+                std::assert(test.flag4 == false, "flag4 was invalid");
+                std::assert(test.flag5 == false, "flag5 was invalid");
                 std::assert(test.enumerated == Enum::A, "enumerated was invalid");
             )";
         }

--- a/tests/include/test_patterns/test_pattern_bitfields.hpp
+++ b/tests/include/test_patterns/test_pattern_bitfields.hpp
@@ -76,11 +76,11 @@ namespace pl::test {
                 };
 
                 bitfield TestBitfield {
-                    a : 2;
+                    unsigned a : 2;
                     b : 3;
                     NestedBitfield c;
                     d : 4;
-                    e : 4;
+                    signed e : 4;
                     NestedBitfield f[c.nestedA];
                 };
 
@@ -91,7 +91,7 @@ namespace pl::test {
                 std::assert(testBitfield.c.nestedA == 0x02, "Nested field A invalid");
                 std::assert(testBitfield.c.nestedB == 0x08, "Nested field B invalid");
                 std::assert(testBitfield.d == 0x08, "Field D invalid");
-                std::assert(testBitfield.e == 0x08, "Field E invalid");
+                std::assert(testBitfield.e == -8, "Field E invalid");
                 std::assert(testBitfield.f[0].nestedA == 0x02, "Nested array[0] field A invalid");
                 std::assert(testBitfield.f[0].nestedB == 0x0A, "Nested array[0] field B invalid");
                 std::assert(testBitfield.f[1].nestedA == 0x08, "Nested array[1] field A invalid");

--- a/tests/include/test_patterns/test_pattern_bitfields.hpp
+++ b/tests/include/test_patterns/test_pattern_bitfields.hpp
@@ -113,7 +113,14 @@ namespace pl::test {
                 bitfieldFields.push_back(create<PatternBitfieldField>("", "flag3", 0x03, 4, 1, testBitfield.get()));
                 bitfieldFields.push_back(create<PatternBitfieldField>("", "flag4", 0x03, 3, 1, testBitfield.get()));
                 bitfieldFields.push_back(create<PatternBitfieldField>("", "flag5", 0x03, 2, 1, testBitfield.get()));
-                bitfieldFields.push_back(create<PatternBitfieldField>("", "enumerated", 0x02, 4, 6, testBitfield.get()));
+
+                auto enumField = create<PatternBitfieldFieldEnum>("Enum", "enumerated", 0x02, 4, 6, testBitfield.get());
+                std::vector<PatternEnum::EnumValue> values;
+                {
+                    values.push_back({ 0x39, 0x39, "A" });
+                }
+                enumField->setEnumValues(std::move(values));
+                bitfieldFields.push_back(std::move(enumField));
             }
 
             testBitfield->setFields(std::move(bitfieldFields));
@@ -129,6 +136,10 @@ namespace pl::test {
             return R"(
                 #pragma endian big
 
+                enum Enum : u8 {
+                    A = 0x39,
+                };
+
                 bitfield Test {
                     flag0 : 1;
                     flag1 : 1;
@@ -136,7 +147,7 @@ namespace pl::test {
                     flag3 : 1;
                     flag4 : 1;
                     flag5 : 1;
-                    enumerated : 6;
+                    Enum enumerated : 6;
                 } [[bitfield_order(1, 16)]];
 
                 Test test @ 2;
@@ -147,7 +158,7 @@ namespace pl::test {
                 std::assert(test.flag3 == 0, "flag3 was invalid");
                 std::assert(test.flag4 == 0, "flag4 was invalid");
                 std::assert(test.flag5 == 0, "flag5 was invalid");
-                std::assert(test.enumerated == 0x39, "enumerated was invalid");
+                std::assert(test.enumerated == Enum::A, "enumerated was invalid");
             )";
         }
     };

--- a/tests/source/tests.cpp
+++ b/tests/source/tests.cpp
@@ -30,6 +30,7 @@ std::array Tests = {
     TEST(SucceedingAssert),
     TEST(FailingAssert),
     TEST(Bitfields),
+    TEST(ReversedBitfields),
     TEST(Math),
     TEST(Matching),
     TEST(RValues),


### PR DESCRIPTION
This adds support for the following bitfields with some typed fields, examples stolen from the tests included in these changes:

```cpp
bitfield NestedBitfield {
    nestedA : 4;
    nestedB : 4;
};

bitfield TestBitfield {
    unsigned a : 2;
    b : 3;
    NestedBitfield c;
    d : 4;
    signed e : 4;
    NestedBitfield f[c.nestedA];
};

be TestBitfield testBitfield @ 0x25;
```

```cpp
#pragma endian big

enum Enum : u8 {
    A = 0x39,
};

bitfield Test {
    bool flag0 : 1;
    bool flag1 : 1;
    bool flag2 : 1;
    bool flag3 : 1;
    bool flag4 : 1;
    bool flag5 : 1;
    Enum enumerated : 6;
} [[bitfield_order(1, 16)]];

Test test @ 2;
```

Functions that interacted with `Evaluator::dataOffset()` will also now use functions each for their intended purpose (getting, incrementing or setting the data offset), and structs and other byte-aligned types can be used within bitfields freely. All of these types will align the read head to the byte boundary.