### PR TITLE
Changes to fix issues editing floating point arrays placed on sections.

### DIFF
--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -400,9 +400,7 @@ namespace pl::core {
                     [&](const double &value) {
                         auto adjustedValue = hlp::changeEndianess(value, pattern->getSize(), pattern->getEndian());
 
-                        storage.resize(pattern->getSize());
-
-                        if (storage.size() == sizeof(float)) {
+                        if (pattern->getSize() == sizeof(float)) {
                             copyToStorage(float(adjustedValue));
                         } else {
                             copyToStorage(adjustedValue);


### PR DESCRIPTION
Issues 1009 WerWolv/ImHex/issues/1009  and 1038 WerWolv/ImHex/issues/1038 deal with problems setting values to  arrays of floating point values that are placed on sections.
The arrays were being resized to size one deleting all but the first and last values (issue 1009) and also resetting the section stack (issue 1038). This PR aims to fix both issues while leaving all other behavior intact.