### PR TITLE
Don't rename variables that are referenced by transform functions

### DIFF
--- a/lib/source/pl/core/ast/ast_node_rvalue.cpp
+++ b/lib/source/pl/core/ast/ast_node_rvalue.cpp
@@ -131,7 +131,9 @@ namespace pl::core::ast {
         }
 
         if (auto transformFunc = evaluator->findFunction(pattern->getTransformFunction()); transformFunc.has_value()) {
+            auto oldPatternName = pattern->getVariableName();
             auto result = transformFunc->func(evaluator, { std::move(literal) });
+            pattern->setVariableName(oldPatternName);
 
             if (!result.has_value())
                 err::E0009.throwError("Transform function did not return a value.", "Try adding a 'return <value>;' statement in all code paths.", this);


### PR DESCRIPTION
Function calls were previously changed to use a shared pointer to patterns that are referenced by parameters. This meant that those patterns would be renamed to the parameter's variable name, which needed to be undone by `ASTNodeFunctionCall`. However, this wasn't mirrored in the call to transform functions in `ASTNodeRValue`, meaning that those could cause variable names to be incorrect.