### PR TITLE
Fixed setDataSource seeking the wrong offset

### DIFF
--- a/cli/source/helpers/utils.cpp
+++ b/cli/source/helpers/utils.cpp
@@ -24,7 +24,8 @@ namespace pl::cli {
         for (const auto &define : defines)
             runtime.addDefine(define);
 
-        runtime.setDataSource(baseAddress, inputFile.getSize(), [&](u64 address, void *buffer, size_t size) {
+        // Include baseAddress as a copy to prevent it from going out of scope in the lambda
+        runtime.setDataSource(baseAddress, inputFile.getSize(), [&inputFile, baseAddress](u64 address, void *buffer, size_t size) {
             inputFile.seek(address - baseAddress);
             inputFile.readBuffer(static_cast<u8*>(buffer), size);
         });


### PR DESCRIPTION
On Unix (or at least Ubuntu), the original line would cause baseAddress to become something else than its intended value after leaving the executePattern method (eg. when the formatter uses the same runtime). I suspected a scope issue, so I changed the baseAddress to be a copy, rather than a reference and this fixed the issue.

I didn't want to change too much, but an alternative method that could also work is adding a getDataBaseAddress to the PatternLanguage-class and use that in the lambda instead.