### PR TITLE
fix: Some errors related to preprocessor and lexer

### DIFF
--- a/lib/include/pl/pattern_language.hpp
+++ b/lib/include/pl/pattern_language.hpp
@@ -81,7 +81,7 @@ namespace pl {
          * @param checkResult Whether to check the result of the execution
          * @return True if the execution was successful, false otherwise
          */
-        [[nodiscard]] bool executeString(std::string code, const std::map<std::string, core::Token::Literal> &envVars = {}, const std::map<std::string, core::Token::Literal> &inVariables = {}, bool checkResult = true);
+        [[nodiscard]] bool executeString(const std::string& code, const std::map<std::string, core::Token::Literal> &envVars = {}, const std::map<std::string, core::Token::Literal> &inVariables = {}, bool checkResult = true);
 
         /**
          * @brief Executes a pattern language file

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -398,7 +398,8 @@ namespace pl::core {
 
                     addToken(tkn::Literal::DocComment(false, std::string(code.substr(commentStart, offset - commentStart))));
 
-                    offset += 2;
+                    line+=1;
+                    offset += 1;
                 } else if (c == '=') {
                     addToken(tkn::Operator::Assign);
                     offset += 1;

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -75,15 +75,13 @@ namespace pl {
         return ast;
     }
 
-    bool PatternLanguage::executeString(std::string code, const std::map<std::string, core::Token::Literal> &envVars, const std::map<std::string, core::Token::Literal> &inVariables, bool checkResult) {
+    bool PatternLanguage::executeString(const std::string& code, const std::map<std::string, core::Token::Literal> &envVars, const std::map<std::string, core::Token::Literal> &inVariables, bool checkResult) {
         auto startTime = std::chrono::high_resolution_clock::now();
         ON_SCOPE_EXIT {
             auto endTime = std::chrono::high_resolution_clock::now();
             this->m_runningTime = std::chrono::duration_cast<std::chrono::duration<double>>(endTime - startTime).count();
         };
 
-        code = wolv::util::replaceStrings(code, "\r\n", "\n");
-        code = wolv::util::replaceStrings(code, "\t", "    ");
 
         auto &evaluator = this->m_internals.evaluator;
 


### PR DESCRIPTION
Doc comments (both single line and multiline) now act as comments during preprocessing stage, but are kept for later use by lexer, which now supports single line doc comments now too.
Improved support for older macs! /hj (files with `\r` as line ending, are now handled by preprocessor by internally converting `\r` and `\r\n` line endings into `\n`).
Using multiline comments no longer mis-aligns execution errors.
Preprocessor directives are now listed in full instead of only "include" "define" and "pragma".
Not having an argument after directives with explicit arguments no longer throws cryptic error if there is no space, and throws an error if there is only a space;