### PR TITLE
Added #undef and some fixes to preprocessor.

### DIFF
--- a/lib/include/pl/api.hpp
+++ b/lib/include/pl/api.hpp
@@ -28,7 +28,7 @@ namespace pl::api {
      */
     using PragmaHandler = std::function<bool(PatternLanguage&, const std::string &)>;
 
-    using DirectiveHandler = std::function<void(core::Preprocessor*, unsigned)>;
+    using DirectiveHandler = std::function<void(core::Preprocessor*, u32)>;
 
     using Resolver = std::function<hlp::Result<Source*, std::string>(const std::string&)>;
 

--- a/lib/include/pl/api.hpp
+++ b/lib/include/pl/api.hpp
@@ -28,7 +28,7 @@ namespace pl::api {
      */
     using PragmaHandler = std::function<bool(PatternLanguage&, const std::string &)>;
 
-    using DirectiveHandler = std::function<void(core::Preprocessor*)>;
+    using DirectiveHandler = std::function<void(core::Preprocessor*, unsigned)>;
 
     using Resolver = std::function<hlp::Result<Source*, std::string>(const std::string&)>;
 

--- a/lib/include/pl/core/lexer.hpp
+++ b/lib/include/pl/core/lexer.hpp
@@ -29,13 +29,18 @@ namespace pl::core {
         std::optional<char> parseCharacter();
         std::optional<Token> parseOperator();
         std::optional<Token> parseSeparator();
+        std::optional<Token> parseOneLineComment();
         std::optional<Token> parseOneLineDocComment();
+        std::optional<Token> parseMultiLineComment();
         std::optional<Token> parseMultiLineDocComment();
         std::optional<Token> parseKeyword(const std::string_view &identifier);
         std::optional<Token> parseType(const std::string_view &identifier);
+        std::optional<Token> parseDirectiveName(const std::string_view &identifier);
         std::optional<Token> parseNamedOperator(const std::string_view &identifier);
         std::optional<Token> parseConstant(const std::string_view &identifier);
         std::optional<Token> parseStringLiteral();
+        std::optional<Token> parseDirectiveArgument();
+        std::optional<Token> parseDirectiveValue();
         std::optional<Token::Literal> parseIntegerLiteral(std::string_view literal);
 
         std::optional<double> parseFloatingPoint(std::string_view literal, char suffix);

--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -32,6 +32,8 @@ namespace pl::core {
         void removeDirectiveHandler(const std::string &directiveType);
 
         std::optional<std::string> getDirectiveValue(bool allowWhitespace = false);
+        void replaceSkippingStrings(std::string &input, const std::string &find, const std::string &replace);
+        void saveDocComment();
 
         [[nodiscard]] bool shouldOnlyIncludeOnce() const {
             return this->m_onlyIncludeOnce;
@@ -59,6 +61,7 @@ namespace pl::core {
         void handleIfDef();
         void handleIfNDef();
         void handleDefine();
+        void handleUnDefine();
         void handlePragma();
         void handleInclude();
         void handleError();
@@ -72,6 +75,9 @@ namespace pl::core {
         std::unordered_map<std::string, api::DirectiveHandler> m_directiveHandlers;
 
         std::unordered_map<std::string, std::pair<std::string, u32>> m_defines;
+        std::map<u32, std::tuple<std::string, std::string, u32 >> m_replacements;
+        std::unordered_map<std::string, u32> m_unDefines;
+        std::vector<std::string> m_docComments;
         std::unordered_map<std::string, std::vector<std::pair<std::string, u32>>> m_pragmas;
 
         std::set<std::string> m_onceIncludedFiles;

--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -24,15 +24,15 @@ namespace pl::core {
 
         ~Preprocessor() override = default;
 
-        hlp::CompileResult<std::vector<pl::core::Token>> preprocess(PatternLanguage *runtime, api::Source* source, bool initialRun = true);
+        hlp::CompileResult<std::vector<Token>> preprocess(PatternLanguage *runtime, api::Source* source, bool initialRun = true);
 
         void addDefine(const std::string &name, const std::string &value = "");
         void addPragmaHandler(const std::string &pragmaType, const api::PragmaHandler &handler);
-        void addDirectiveHandler(const std::string &directiveType, const api::DirectiveHandler &handler);
+        void addDirectiveHandler(const Token::Directive &directiveType, const api::DirectiveHandler &handler);
         void removePragmaHandler(const std::string &pragmaType);
-        void removeDirectiveHandler(const std::string &directiveType);
+        void removeDirectiveHandler(const Token::Directive &directiveType);
 
-        std::optional<pl::core::Token> getDirectiveValue(unsigned line);
+        std::optional<Token> getDirectiveValue(u32 line);
 
         [[nodiscard]] bool shouldOnlyIncludeOnce() const {
             return this->m_onlyIncludeOnce;
@@ -51,31 +51,24 @@ namespace pl::core {
 
         Location location() override;
 
-        inline std::string peek(i32 p = 0) const {
-            if( (m_token + p)  >=  m_result.unwrap().end()) return "EOF";
-            return (m_token+p)->getFormattedValue();
-        }
-
-        std::string parseDirectiveName();
-
         // directive handlers
-        void handleIfDef(unsigned line);
-        void handleIfNDef(unsigned line);
-        void handleDefine(unsigned line);
-        void handleUnDefine(unsigned line);
-        void handlePragma(unsigned line);
-        void handleInclude(unsigned line);
-        void handleError(unsigned line);
+        void handleIfDef(u32 line);
+        void handleIfNDef(u32 line);
+        void handleDefine(u32 line);
+        void handleUnDefine(u32 line);
+        void handlePragma(u32 line);
+        void handleInclude(u32 line);
+        void handleError(u32 line);
 
         void process();
         void processIfDef(bool add);
 
-        void registerDirectiveHandler(const std::string& name, auto memberFunction);
+        void registerDirectiveHandler(const Token::Directive &name, auto memberFunction);
 
         std::unordered_map<std::string, api::PragmaHandler> m_pragmaHandlers;
-        std::unordered_map<std::string, api::DirectiveHandler> m_directiveHandlers;
+        std::unordered_map<Token::Directive, api::DirectiveHandler> m_directiveHandlers;
 
-        std::unordered_map<std::string, std::vector<pl::core::Token>> m_defines;
+        std::unordered_map<std::string, std::vector<Token>> m_defines;
         std::unordered_map<std::string, std::vector<std::pair<std::string, u32>>> m_pragmas;
 
         std::set<std::string> m_onceIncludedFiles;
@@ -83,11 +76,11 @@ namespace pl::core {
         api::Resolver m_resolver = nullptr;
         PatternLanguage *m_runtime = nullptr;
 
-        std::vector<pl::core::Token> m_keys;
+        std::vector<Token> m_keys;
         std::atomic<bool> m_initialized = false;
-        __gnu_cxx::__normal_iterator<pl::core::Token *, std::vector<pl::core::Token>> m_token;
-        hlp::CompileResult<std::vector<pl::core::Token>> m_result;
-        std::vector<pl::core::Token> m_output;
+        std::vector<Token>::iterator m_token;
+        hlp::CompileResult<std::vector<Token>> m_result;
+        std::vector<Token> m_output;
 
         api::Source* m_source = nullptr;
 

--- a/lib/include/pl/core/token.hpp
+++ b/lib/include/pl/core/token.hpp
@@ -21,9 +21,10 @@ namespace pl::core {
     class Token {
     public:
         static std::map<std::string_view, Token>& Operators();
-        static std::map<char,             Token>& Seperators();
+        static std::map<char,             Token>& Separators();
         static std::map<std::string_view, Token>& Keywords();
         static std::map<std::string_view, Token>& Types();
+        static std::map<std::string_view, Token>& Directives();
 
         Token() = default;
 
@@ -35,7 +36,9 @@ namespace pl::core {
             String,
             Identifier,
             Separator,
-            DocComment
+            DocComment,
+            Comment,
+            Directive
         };
 
         enum class Keyword {
@@ -153,6 +156,17 @@ namespace pl::core {
             EndOfProgram
         };
 
+        enum class Directive {
+            Include,
+            Define,
+            IfDef,
+            IfNDef,
+            EndIf,
+            Undef,
+            Error,
+            Pragma
+        };
+
         struct Identifier {
             explicit Identifier(std::string identifier) : m_identifier(std::move(identifier)) { }
 
@@ -169,6 +183,12 @@ namespace pl::core {
             std::string comment;
 
             constexpr bool operator==(const DocComment &) const = default;
+        };
+
+        struct Comment {
+            std::string comment;
+
+            constexpr bool operator==(const Comment &) const = default;
         };
 
         struct Literal : std::variant<char, bool, u128, i128, double, std::string, std::shared_ptr<ptrn::Pattern>> {
@@ -196,7 +216,7 @@ namespace pl::core {
             [[nodiscard]] std::strong_ordering operator<=>(const Literal &other) const;
         };
 
-        using ValueTypes = std::variant<Keyword, Identifier, Operator, Literal, ValueType, Separator, DocComment>;
+        using ValueTypes = std::variant<Keyword, Identifier, Operator, Literal, ValueType, Separator, Comment, DocComment, Directive>;
 
         constexpr Token(const Type type, auto value, const Location location) : type(type), value(std::move(value)), location(location) {}
 

--- a/lib/include/pl/core/tokens.hpp
+++ b/lib/include/pl/core/tokens.hpp
@@ -76,6 +76,10 @@ namespace pl::core::tkn {
             return { core::Token::Type::DocComment, Token::DocComment { global, value }, Location::Empty() };
         }
 
+        inline Token makeComment(const std::string &value) {
+            return { core::Token::Type::Comment, Token::Comment { value }, Location::Empty() };
+        }
+
         const auto Identifier = makeToken(core::Token::Type::Identifier, { });
         const auto Numeric    = makeToken(core::Token::Type::Integer, { });
         const auto String     = makeToken(core::Token::Type::String,  { });
@@ -176,7 +180,7 @@ namespace pl::core::tkn {
 
         inline Token makeSeparator(const Token::Separator& value, char name) {
             auto token = makeToken(Token::Type::Separator, value);
-            Token::Seperators()[name] = token;
+            Token::Separators()[name] = token;
             return token;
         }
 
@@ -192,6 +196,24 @@ namespace pl::core::tkn {
 
         const auto EndOfProgram = makeToken(Token::Type::Separator, Token::Separator::EndOfProgram);
 
+    }
+
+    namespace Directive {
+
+        inline Token makeDirective(const Token::Directive& value, const std::string_view& name) {
+            auto token = makeToken(core::Token::Type::Directive, value);
+            Token::Directives()[name] = token;
+            return token;
+        }
+
+        const auto Include = makeDirective(Token::Directive::Include, "#include");
+        const auto Define = makeDirective(Token::Directive::Define, "#define");
+        const auto Undef = makeDirective(Token::Directive::Undef, "#undef");
+        const auto IfDef = makeDirective(Token::Directive::IfDef, "#ifdef");
+        const auto IfNDef = makeDirective(Token::Directive::IfNDef, "#ifndef");
+        const auto EndIf = makeDirective(Token::Directive::EndIf, "#endif");
+        const auto Error = makeDirective(Token::Directive::Error, "#error");
+        const auto Pragma = makeDirective(Token::Directive::Pragma, "#pragma");
     }
 
 }

--- a/lib/include/pl/pattern_language.hpp
+++ b/lib/include/pl/pattern_language.hpp
@@ -70,20 +70,13 @@ namespace pl {
         };
 
         /**
-        * @brief Preprocesses a pattern language code string and returns the preprocessed code
+        * @brief Lexes and preprocesses a pattern language code string and returns a token stream
         * @param code Code to preprocess
         * @param source Source of the code
-        * @return Preprocessed source
+        * @return token stream
         */
-        [[nodiscard]] std::optional<api::Source*> preprocessString(const std::string &code, const std::string &source);
+        [[nodiscard]] std::optional<std::vector<pl::core::Token>> preprocessString(const std::string &code, const std::string &source);
 
-        /**
-        * @brief Lexes a pattern language code string and returns the generated tokens
-        * @param code Code to lex
-        * @param source Source of the code
-        * @return Generated Tokens
-        */
-        [[nodiscard]] std::optional<std::vector<pl::core::Token>> lexString(const std::string &code, const std::string &source);
 
         /**
          * @brief Parses a pattern language code string and returns the generated AST

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -106,12 +106,10 @@ namespace pl::core {
     }
 
     std::optional<Token> Lexer::parseDirectiveName(const std::string_view &identifier) {
-        auto directives = Token::Directives();
-
-        if (const auto directiveToken = directives.find(identifier); directiveToken != directives.end())
-
+        const auto &directives = Token::Directives();
+        if (const auto directiveToken = directives.find(identifier); directiveToken != directives.end()) {
             return makeToken(directiveToken->second, identifier.length());
-
+        }
         return std::nullopt;
     }
 
@@ -149,10 +147,9 @@ namespace pl::core {
         while (m_sourceCode[m_cursor] != '\n' && m_sourceCode[m_cursor] != '\0') {
 
             auto character = parseCharacter();
-
-            if (!character.has_value())
-
+            if (!character.has_value()) {
                 return std::nullopt;
+            }
 
             result += character.value();
         }
@@ -329,7 +326,6 @@ namespace pl::core {
             m_cursor++;
 
         }
-
         if (m_sourceCode[m_cursor] == '\n') {
             m_line++;
             m_lineBegin = m_cursor;
@@ -583,7 +579,7 @@ namespace pl::core {
 
             if (c == '#' && (m_tokens.empty() ||  m_tokens.back().location.line < m_line)) {
                 size_t length = 1;
-                unsigned line = m_line;
+                u32 line = m_line;
                 while (isIdentifierCharacter(peek(length)))
                     length++;
                 auto directiveName = std::string_view{&m_sourceCode[m_cursor], length};

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -444,7 +444,7 @@ namespace pl::core {
                 }
                 if(category == '*') {
                     if(type != '!' && type != '*') {
-                        error("Invalid documentation comment. Expected '/**' or '/*!', got '/*{}", type);
+                        error("Invalid documentation comment. Expected '/**' or '/*!', got '/*{}'", type);
                         // forward
                         m_cursor++;
                         continue;

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -105,6 +105,67 @@ namespace pl::core {
         return c;
     }
 
+    std::optional<Token> Lexer::parseDirectiveName(const std::string_view &identifier) {
+        auto directives = Token::Directives();
+
+        if (const auto directiveToken = directives.find(identifier); directiveToken != directives.end())
+
+            return makeToken(directiveToken->second, identifier.length());
+
+        return std::nullopt;
+    }
+
+    std::optional<Token> Lexer::parseDirectiveValue() {
+        std::string result;
+
+        m_cursor++; // Skip space
+        auto location = this->location();
+
+        while (!std::isblank(m_sourceCode[m_cursor]) && !std::isspace(m_sourceCode[m_cursor]) ) {
+
+            auto character = parseCharacter();
+            if (!character.has_value()) {
+                return std::nullopt;
+            }
+
+            result += character.value();
+        }
+
+        if (m_sourceCode[m_cursor] == '\n') {
+            m_line++;
+            m_lineBegin = m_cursor;
+            m_cursor++;
+        }
+
+        return makeTokenAt(Literal::makeString(result), location, result.size());
+    }
+
+    std::optional<Token> Lexer::parseDirectiveArgument() {
+        std::string result;
+
+        m_cursor++; // Skip space
+        auto location = this->location();
+
+        while (m_sourceCode[m_cursor] != '\n' && m_sourceCode[m_cursor] != '\0') {
+
+            auto character = parseCharacter();
+
+            if (!character.has_value())
+
+                return std::nullopt;
+
+            result += character.value();
+        }
+
+        if (m_sourceCode[m_cursor] == '\n') {
+            m_line++;
+            m_lineBegin = m_cursor;
+            m_cursor++;
+        }
+
+        return makeTokenAt(Literal::makeString(result), location, result.size());
+    }
+
     std::optional<Token> Lexer::parseStringLiteral() {
         std::string result;
         auto location = this->location();
@@ -237,20 +298,42 @@ namespace pl::core {
         return i128(value);
     }
 
+    std::optional<Token> Lexer::parseOneLineComment() {
+        auto location = this->location();
+        const auto begin = m_cursor;
+        m_cursor += 2;
+
+        std::string result;
+        while(m_sourceCode[m_cursor] != '\n' && m_sourceCode[m_cursor] != '\0') {
+            result += peek();
+            m_cursor++;
+        }
+
+        if (m_sourceCode[m_cursor] == '\n') {
+            m_line++;
+            m_lineBegin = m_cursor;
+            m_cursor++;
+        }
+
+        return makeTokenAt(Literal::makeComment(result), location, m_cursor - begin);
+    }
+
     std::optional<Token> Lexer::parseOneLineDocComment() {
         auto location = this->location();
         const auto begin = m_cursor;
         m_cursor += 3;
 
         std::string result;
-        while(m_sourceCode[m_cursor] != '\n') {
+        while(m_sourceCode[m_cursor] != '\n' && m_sourceCode[m_cursor] != '\0') {
             result += peek();
             m_cursor++;
 
-            if(peek(1) == 0) {
-                error("Unexpected end of file while parsing one line doc comment");
-                return std::nullopt;
-            }
+        }
+
+        if (m_sourceCode[m_cursor] == '\n') {
+            m_line++;
+            m_lineBegin = m_cursor;
+            m_cursor++;
         }
 
         return makeTokenAt(Literal::makeDocComment(false, result), location, m_cursor - begin);
@@ -274,7 +357,7 @@ namespace pl::core {
                 return std::nullopt;
             }
 
-            if(peek(1) == '*' && peek(2) == '/') {
+            if(peek(0) == '*' && peek(1) == '/') {
                 m_cursor += 2;
                 break;
             }
@@ -283,6 +366,34 @@ namespace pl::core {
         }
 
         return makeTokenAt(Literal::makeDocComment(global, result), location, m_cursor - begin);
+    }
+
+    std::optional<Token> Lexer::parseMultiLineComment() {
+        auto location = this->location();
+        const auto begin = m_cursor;
+        std::string result;
+
+        m_cursor += 2;
+        while(true) {
+            if(peek(0) == '\n') {
+                m_line++;
+                m_lineBegin = m_cursor;
+            }
+
+            if(peek(1) == '\x00') {
+                error("Unexpected end of file while parsing multi line doc comment");
+                return std::nullopt;
+            }
+
+            if(peek(0) == '*' && peek(1) == '/') {
+                m_cursor += 2;
+                break;
+            }
+
+            result += m_sourceCode[m_cursor++];
+        }
+
+        return makeTokenAt(Literal::makeComment(result), location, m_cursor - begin);
     }
 
     std::optional<Token> Lexer::parseOperator() {
@@ -306,8 +417,8 @@ namespace pl::core {
         auto location = this->location();
         const auto begin = m_cursor;
 
-        if (const auto separatorToken = Token::Seperators().find(m_sourceCode[m_cursor]);
-            separatorToken != Token::Seperators().end()) {
+        if (const auto separatorToken = Token::Separators().find(m_sourceCode[m_cursor]);
+            separatorToken != Token::Separators().end()) {
             m_cursor++;
             return makeTokenAt(separatorToken->second, location, m_cursor - begin);
             }
@@ -436,24 +547,24 @@ namespace pl::core {
                             addToken(token.value());
                         }
                     } else {
-                        error("Expected '/' after '//' but got '//{}'", type);
-                        // forward
-                        m_cursor++;
+                        const auto token = parseOneLineComment();
+                        if(token.has_value()) {
+                            addToken(token.value());
+                        }
                     }
                     continue;
                 }
                 if(category == '*') {
-                    if(type != '!' && type != '*') {
-                        error("Invalid documentation comment. Expected '/**' or '/*!', got '/*{}'", type);
-                        // forward
-                        m_cursor++;
+                    if (type != '!' && (type != '*' || peek(3) == '/' )) {
+                        const auto token = parseMultiLineComment();
+                        if(token.has_value())
+                            addToken(token.value());
                         continue;
                     }
                     const auto token = parseMultiLineDocComment();
                     if(token.has_value()) {
                         addToken(token.value());
                     }
-                    m_cursor++; // skip closing /
                     continue;
                 }
             }
@@ -468,6 +579,44 @@ namespace pl::core {
             if (separatorToken.has_value()) {
                 addToken(separatorToken.value());
                 continue;
+            }
+
+            if (c == '#' && (m_tokens.empty() ||  m_tokens.back().location.line < m_line)) {
+                size_t length = 1;
+                unsigned line = m_line;
+                while (isIdentifierCharacter(peek(length)))
+                    length++;
+                auto directiveName = std::string_view{&m_sourceCode[m_cursor], length};
+
+                if (processToken(&Lexer::parseDirectiveName, directiveName)) {
+                    if (m_line != line || directiveName == "#define") {
+                        continue;
+                    }
+                    if (peek(0) == '\n') {
+                        m_line++;
+                        m_lineBegin = m_cursor;
+                        m_cursor++;
+                        continue;
+                    }
+                    auto string = parseDirectiveValue();
+                    if (string.has_value()) {
+                        addToken(string.value());
+                        if (m_line != line) {
+                            continue;
+                        }
+                        if (peek(0) == '\n') {
+                            m_line++;
+                            m_lineBegin = m_cursor;
+                            m_cursor++;
+                            continue;
+                        }
+                        string = parseDirectiveArgument();
+                        if (string.has_value()) {
+                            addToken(string.value());
+                        }
+                    }
+                    continue;
+                }
             }
 
             // literals

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -321,7 +321,7 @@ namespace pl::core {
         m_cursor += 3;
 
         std::string result;
-        while(m_sourceCode[m_cursor] != '\n' && m_sourceCode[m_cursor] != '\0') {
+        while (m_sourceCode[m_cursor] != '\n' && m_sourceCode[m_cursor] != '\0') {
             result += peek();
             m_cursor++;
 
@@ -353,7 +353,7 @@ namespace pl::core {
                 return std::nullopt;
             }
 
-            if(peek(0) == '*' && peek(1) == '/') {
+            if (peek(0) == '*' && peek(1) == '/') {
                 m_cursor += 2;
                 break;
             }
@@ -550,7 +550,7 @@ namespace pl::core {
                     }
                     continue;
                 }
-                if(category == '*') {
+                if (category == '*') {
                     if (type != '!' && (type != '*' || peek(3) == '/' )) {
                         const auto token = parseMultiLineComment();
                         if(token.has_value())
@@ -558,7 +558,7 @@ namespace pl::core {
                         continue;
                     }
                     const auto token = parseMultiLineDocComment();
-                    if(token.has_value()) {
+                    if (token.has_value()) {
                         addToken(token.value());
                     }
                     continue;

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -2092,11 +2092,8 @@ namespace pl::core {
                 break;
         }
 
-        if(isAliased) {
-            // if aliased skip this namespace
+        if(isAliased) // if aliased skip this namespace
             this->m_currNamespace.pop_back();
-            return { };
-        }
 
         if (!sequence(tkn::Separator::LeftBrace)) {
             error("Expected '{{' at beginning of namespace, got {}.", getFormattedToken(0));
@@ -2108,7 +2105,8 @@ namespace pl::core {
             std::ranges::move(newStatements, std::back_inserter(statements));
         }
 
-        this->m_currNamespace.pop_back();
+        if(!isAliased) // if aliased already done this
+            this->m_currNamespace.pop_back();
 
         return statements;
     }

--- a/lib/source/pl/core/parser_manager.cpp
+++ b/lib/source/pl/core/parser_manager.cpp
@@ -26,24 +26,15 @@ pl::hlp::CompileResult<ParserManager::ParsedData> ParserManager::parse(api::Sour
 
     const auto& preprocessor = internals.preprocessor;
 
-    const auto& lexer = internals.lexer;
     const auto& validator = internals.validator;
 
-    auto [preprocessedCode, preprocessorErrors] = preprocessor->preprocess(this->m_patternLanguage, source);
+    auto [tokens, preprocessorErrors] = preprocessor->preprocess(this->m_patternLanguage, source, true);
     if (!preprocessorErrors.empty()) {
         return result_t::err(preprocessorErrors);
     }
 
-    source->content = preprocessedCode.value();
-
     if(preprocessor->shouldOnlyIncludeOnce())
         m_onceIncluded.insert( { source, namespacePrefix } );
-
-    auto [tokens, lexerErrors] = lexer->lex(source);
-
-    if (!lexerErrors.empty()) {
-        return result_t::err(lexerErrors);
-    }
 
     parser.setParserManager(this);
     parser.setAliasNamespace(namespaces);
@@ -53,7 +44,7 @@ pl::hlp::CompileResult<ParserManager::ParsedData> ParserManager::parse(api::Sour
         return result_t::err(result.errs);
 
     // if its ok validate before returning
-    auto [validated, validatorErrors] = validator->validate(*result.ok);
+    auto [validated, validatorErrors] = validator->validate(result.ok.value());
     if (validated && !validatorErrors.empty()) {
         return result_t::err(validatorErrors);
     }

--- a/lib/source/pl/core/parser_manager.cpp
+++ b/lib/source/pl/core/parser_manager.cpp
@@ -38,16 +38,16 @@ pl::hlp::CompileResult<ParserManager::ParsedData> ParserManager::parse(api::Sour
 
     const auto& validator = internals.validator;
 
-    auto [tokens, preprocessorErrors] = preprocessor->preprocess(this->m_patternLanguage, source, true);
+    auto [tokens, preprocessorErrors] = preprocessor.preprocess(this->m_patternLanguage, source, true);
     if (!preprocessorErrors.empty()) {
         return result_t::err(preprocessorErrors);
     }
 
-    if(preprocessor->shouldOnlyIncludeOnce())
+    if(preprocessor.shouldOnlyIncludeOnce())
         m_onceIncluded.insert( { source, namespacePrefix } );
 
-    parser.setParserManager(this);
-    parser.setAliasNamespace(namespaces);
+    parser.m_parserManager = this;
+    parser.m_aliasNamespace = namespaces;
     parser.m_aliasNamespaceString = namespacePrefix;
 
     auto result = parser.parse(tokens.value());

--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -230,8 +230,8 @@ namespace pl::core {
             return;
         }
 
-        if (!includeFile.starts_with('"') || !includeFile.ends_with('"') ||
-            !includeFile.starts_with('<') || !includeFile.ends_with('>')) {
+        if ((!includeFile.starts_with('"') || !includeFile.ends_with('"')) &&
+            (!includeFile.starts_with('<') || !includeFile.ends_with('>'))) {
             errorDesc("Invalid file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
             return;
         }

--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -48,7 +48,7 @@ namespace pl::core {
         });
     }
 
-    std::string getTokenValue(const Token& token) {
+    std::string getTokenValue(const Token &token) {
         auto identifier = token.getFormattedValue();
         if (identifier.length() > 1 )
             return identifier.substr(1, identifier.length() - 2);
@@ -76,7 +76,7 @@ namespace pl::core {
         return true;
     }
 
-    bool operator==(const std::vector<pl::core::Token>& a, const std::vector<pl::core::Token>& b) {
+    bool operator==(const std::vector<pl::core::Token> &a, const std::vector<pl::core::Token> &b) {
         if (a.size() != b.size())
             return false;
         for (u32 i = 0; i < a.size(); i++)
@@ -103,7 +103,7 @@ namespace pl::core {
         // find the next #endif
         const Location start = location();
         u32 depth = 1;
-        while(m_token != m_result.unwrap().end() && depth > 0) {
+        while (m_token != m_result.unwrap().end() && depth > 0) {
             if (m_token->type == pl::core::Token::Type::Directive) {
                 Token::Directive directive = get<Token::Directive>(m_token->value);
                 if (directive == pl::core::Token::Directive::EndIf) {
@@ -125,8 +125,9 @@ namespace pl::core {
                             depth--;
                         }
                     }
-                } else
+                } else {
                     m_token++;
+                }
             }
         }
 
@@ -139,7 +140,7 @@ namespace pl::core {
     void Preprocessor::handleIfDef(u32 line) {
         auto token = getDirectiveValue(line);
 
-        if(!isNameValid(token)) {
+        if (!isNameValid(token)) {
             error("Expected identifier after #ifdef");
             return;
         }
@@ -150,7 +151,7 @@ namespace pl::core {
     void Preprocessor::handleIfNDef(u32 line) {
         auto token = getDirectiveValue(line);
 
-        if(!isNameValid(token)) {
+        if (!isNameValid(token)) {
             error("Expected identifier after #ifndef");
             return;
         }
@@ -161,12 +162,14 @@ namespace pl::core {
     void Preprocessor::handleDefine(u32 line) {
         auto token = getDirectiveValue(line);
 
-        if(!isNameValid(token)) {
+        if (!isNameValid(token)) {
             error("Expected identifier after #define");
             return;
         }
+
         auto tokenValue = token.value();
         auto name = getTokenValue(tokenValue);
+
         std::vector<Token> values;
         auto replacement = getDirectiveValue(line);
         while (replacement.has_value()) {
@@ -197,6 +200,7 @@ namespace pl::core {
             error("Expected identifier after #undef");
             return;
         }
+
         auto name = getOptionalValue(token);
         if (m_defines.contains(name)) {
             m_defines.erase(name);
@@ -207,10 +211,11 @@ namespace pl::core {
     void Preprocessor::handlePragma(u32 line) {
         auto token = getDirectiveValue(line);
 
-        if(!token.has_value()) {
+        if (!token.has_value()) {
             errorDesc("No instruction given in #pragma directive.", "A #pragma directive expects a instruction followed by an optional value in the form of #pragma <instruction> <value>.");
             return;
         }
+
         auto key = getOptionalValue(token);
         token = getDirectiveValue(line);
         if (!token.has_value())
@@ -225,6 +230,7 @@ namespace pl::core {
             errorDesc("No file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
             return;
         }
+
         auto includeFile = getOptionalValue(token);
 
         if (includeFile.empty()){
@@ -304,7 +310,7 @@ namespace pl::core {
             Token::Directive directive = get<Token::Directive>(m_token->value);
             auto handler = m_directiveHandlers.find(directive);
             if (directive == Token::Directive::EndIf) {
-                // happens in nested #ifdefs
+                // Happens in nested #ifdefs
                 return;
             } else if(handler == m_directiveHandlers.end()) {
                 error("Unknown directive '{}'", m_token->getFormattedValue());
@@ -333,6 +339,7 @@ namespace pl::core {
                 values = resultValues;
                 resultValues.clear();
             }
+
             for (const auto &value: values)
                 m_output.push_back(value);
             m_token++;
@@ -343,7 +350,7 @@ namespace pl::core {
     void Preprocessor::handleError(u32 line) {
         auto token = getDirectiveValue(line);
 
-        if(token.has_value()) {
+        if (token.has_value()) {
             auto message = token.value().getFormattedValue();
             error(message);
         } else {
@@ -400,7 +407,18 @@ namespace pl::core {
     }
 
     void Preprocessor::addDefine(const std::string &name, const std::string &value) {
-        m_defines[name] = {pl::core::Token { pl::core::Token::Type::Directive, name, location() },pl::core::Token { pl::core::Token::Type::String, value, location() } };
+        m_defines[name] = { 
+            pl::core::Token { 
+                pl::core::Token::Type::Directive, 
+                name, 
+                location() 
+            }, 
+            pl::core::Token { 
+                pl::core::Token::Type::String, 
+                value, 
+                location() 
+            } 
+        };
     }
 
     void Preprocessor::addPragmaHandler(const std::string &pragmaType, const api::PragmaHandler &handler) {
@@ -423,10 +441,10 @@ namespace pl::core {
         if (isInitialized())
             return m_token->location;
         else
-            return {nullptr, 0, 0, 0 };
+            return { nullptr, 0, 0, 0 };
     }
 
-    void Preprocessor::registerDirectiveHandler(const Token::Directive& name, auto memberFunction) {
+    void Preprocessor::registerDirectiveHandler(const Token::Directive &name, auto memberFunction) {
         this->m_directiveHandlers[name] = [memberFunction](Preprocessor* preprocessor, u32 line){
             (preprocessor->*memberFunction)(line);
         };

--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -2,16 +2,12 @@
 
 #include <wolv/utils/string.hpp>
 
-namespace pl::core {
+#include <pl/pattern_language.hpp>
+#include <pl/core/lexer.hpp>
+#include <pl/core/tokens.hpp>
+#include <pl/core/parser.hpp>
 
-    static bool isNameValid(std::optional<std::string> name) {
-        if (!name.has_value() || name->empty())
-            return false;
-        for (auto letter:*name)
-            if (!std::isalnum(letter) && letter != '_')
-                return false;
-        return true;
-    }
+namespace pl::core {
 
     Preprocessor::Preprocessor() : ErrorCollector() {
         this->addPragmaHandler("once", [this](PatternLanguage&, const std::string &value) {
@@ -21,20 +17,17 @@ namespace pl::core {
         });
 
         // register directive handlers
-        registerDirectiveHandler("ifdef", &Preprocessor::handleIfDef);
-        registerDirectiveHandler("ifndef", &Preprocessor::handleIfNDef);
-        registerDirectiveHandler("define", &Preprocessor::handleDefine);
-        registerDirectiveHandler("undef", &Preprocessor::handleUnDefine);
-        registerDirectiveHandler("pragma", &Preprocessor::handlePragma);
-        registerDirectiveHandler("include", &Preprocessor::handleInclude);
-        registerDirectiveHandler("error", &Preprocessor::handleError);
+        registerDirectiveHandler("#ifdef", &Preprocessor::handleIfDef);
+        registerDirectiveHandler("#ifndef", &Preprocessor::handleIfNDef);
+        registerDirectiveHandler("#define", &Preprocessor::handleDefine);
+        registerDirectiveHandler("#undef", &Preprocessor::handleUnDefine);
+        registerDirectiveHandler("#pragma", &Preprocessor::handlePragma);
+        registerDirectiveHandler("#include", &Preprocessor::handleInclude);
+        registerDirectiveHandler("#error", &Preprocessor::handleError);
     }
 
     Preprocessor::Preprocessor(const Preprocessor &other) : ErrorCollector(other) {
         this->m_defines = other.m_defines;
-        this->m_replacements = other.m_replacements;
-        this->m_unDefines = other.m_unDefines;
-        this->m_docComments = other.m_docComments;
         this->m_pragmas = other.m_pragmas;
         this->m_onceIncludedFiles = other.m_onceIncludedFiles;
         this->m_resolver = other.m_resolver;
@@ -42,6 +35,10 @@ namespace pl::core {
         this->m_pragmaHandlers = other.m_pragmaHandlers;
         this->m_directiveHandlers = other.m_directiveHandlers;
         this->m_runtime = other.m_runtime;
+        this->m_keys = other.m_keys;
+        this->m_initialized = false;
+        this->m_source = other.m_source;
+        this->m_output.clear();
 
         // need to update, because old handler points to old `this`
         this->addPragmaHandler("once", [this](PatternLanguage&, const std::string &value) {
@@ -51,158 +48,83 @@ namespace pl::core {
         });
     }
 
-    std::optional<std::string> Preprocessor::getDirectiveValue(const bool allowWhitespace) {
-        while (std::isblank(peek())) {
-            m_offset++;
-            if (peek() == '\n' || peek() == '\r')
-                return std::nullopt;
-        }
+    std::string getTokenValue(const Token& token) {
+        auto identifier = token.getFormattedValue();
+        if (identifier.length() > 1 )
+            return identifier.substr(1, identifier.length() - 2);
+        else
+            return identifier;
+    }
 
-        std::string value;
-        char c = peek();
-        while ((allowWhitespace || !std::isblank(c)) && c != '\n' && c != '\r') {
-            value += c;
+    std::string getOptionalValue(std::optional<Token> token) {
+        if (!token.has_value())
+            return "";
+        return getTokenValue(token.value());
+    }
 
-            c = m_code[++m_offset];
-            if (m_offset >= m_code.length())
-                break;
-        }
+    static bool isNameValid(const std::optional<pl::core::Token> &token) {
+        if (!token.has_value())
+            return false;
+        auto name = getOptionalValue(token);
+        if (name.empty())
+            return false;
+        // replace with std::ranges::all_of when available
+        std::ranges::all_of(name, [](char c) {
+            return std::isalnum(c) || c == '_';
+        });
 
-        return wolv::util::trim(value);
+        return true;
+    }
+
+    bool operator==(const std::vector<pl::core::Token>& a, const std::vector<pl::core::Token>& b) {
+        if (a.size() != b.size())
+            return false;
+        for (u32 i = 0; i < a.size(); i++)
+            if (getTokenValue(a[i]) != getTokenValue(b[i]))
+                return false;
+        return true;
+    }
+
+    void removeValue(std::vector<pl::core::Token> &vec,const std::string &name) {
+        for (unsigned i = 0; i < vec.size(); i++)
+            if (getTokenValue(vec[i]) == name)
+                vec.erase(vec.begin() + i);
+    }
+
+    std::optional<pl::core::Token> Preprocessor::getDirectiveValue(unsigned line) {
+        const pl::core::Token &token = *m_token;
+        if (m_token->location.line != line || m_token >= m_result.unwrap().end())
+            return std::nullopt;
+        m_token++;
+        return token;
     }
 
     std::string Preprocessor::parseDirectiveName() {
-        const std::string_view view = &m_code[m_offset];
-        auto end = view.find_first_of(" \t\n\r");
-
-        if(end == std::string_view::npos)
-            end = view.length();
-
-        m_offset += end;
-
-        return std::string(view.substr(0, end));
-    }
-
-    void Preprocessor::saveDocComment() {
-        std::string comment = "";
-        u32 lineCount = 0;
-        if (peek() == '/' && peek(1) =='/' && peek(2) == '/') {
-            comment += "///";
-            m_offset += 3;
-            while (peek() != 0 && peek() != '\n') {
-                comment += peek();
-                m_offset++;
-            }
-            m_offset++;
-            lineCount = 1;
-        } else {
-            comment += "/*";
-            this->m_offset += 2;
-            comment += peek();
-            this->m_offset++;
-            while (peek() != 0 && (peek() != '*' || peek(1) != '/')) {
-                if (peek() == '\n') {
-                    this->m_lineNumber++;
-                    this->m_lineBeginOffset = this->m_offset;
-                    lineCount++;
-                }
-                comment += peek();
-                this->m_offset++;
-            }
-            comment += "*/";
-            this->m_offset += 2;
-        }
-        this->m_docComments.push_back(comment);
-        this->m_output += (char) 0x80;
-        this->m_output += this->m_docComments.size();
-        this->m_output += std::string(lineCount, '\n');
-    }
-
-    // Avoid define replacements in doc comments by saving them to
-    // a container and placing a marker and newlines to preserve line numbers
-    void Preprocessor::parseComment() {
-        char type = peek(1);
-        char next = peek(2);
-
-        if (type == '/') {
-            if (next == '/') {
-                saveDocComment();
-                return;
-            } else
-                while (peek() != 0 && peek() != '\n') m_offset++;
-
-        } else if (type == '*') {
-
-            if ((next == '*' && peek(3) != '/') || next == '!') {
-                saveDocComment();
-                return;
-            }
-            while (peek() != 0 && (peek() != '*' || peek(1) != '/')) {
-                // update lines
-                if (peek() == '\n') {
-                    m_output += '\n';
-                    m_lineNumber++;
-                    m_lineBeginOffset = m_offset;
-                }
-
-                m_offset++;
-            }
-
-            m_offset += 2;
-            // add spaces to ensure column location of errors is correct.
-            u32 i = 0;
-            bool needsSpaces = false;
-            const std::string_view view = &m_code[m_offset];
-            auto end = view.find_first_of("\0\n\r");
-
-            if(end == std::string_view::npos)
-                end = view.length();
-
-            while (i < end) {
-                if (!std::isspace(view[i])) {
-                    needsSpaces = true;
-                    break;
-                }
-                i++;
-            }
-            if (needsSpaces) {
-                u32 spaceCount = m_offset - m_lineBeginOffset;
-                m_output += std::string(spaceCount, ' ');
-            }
-        }
+        auto result = m_token->getFormattedValue();
+        m_token++;
+        return result;
     }
 
     void Preprocessor::processIfDef(const bool add) {
         // find the next #endif
         const Location start = location();
         u32 depth = 1;
-        while(peek() != 0 && depth > 0) {
-            if(m_code.substr(m_offset, 6) == "#endif" && !m_inString && m_startOfLine) {
-                m_offset += 6;
+        while(peek() != "EOF" && depth > 0) {
+            if(m_token->getFormattedValue() == "#endif") {
+                m_token++;
                 depth--;
             }
             if(add) process();
             else {
-                char c = peek();
-                if(c == '\n') {
-                    m_lineNumber++;
-                    m_lineBeginOffset = m_offset;
-                    m_startOfLine = true;
-                    m_output += c;
-                } else if (c == '#' && !m_inString && m_startOfLine) {
-                    m_offset++;
-                    // handle ifdef and ifndef
-                    std::string name = parseDirectiveName();
-                    if(name == "ifdef" || name == "ifndef") {
-                        depth++;
-                    }
-                } else if(!std::isspace(c)) {
-                    m_startOfLine = false;
-                } else if(c == '"') {
-                    m_inString = !m_inString;
+                std::string name = parseDirectiveName();
+                if(name == "#ifdef" || name == "#ifndef")
+                    depth++;
+                else if(name == "#endif") {
+                    if (depth > 0)
+                        depth--;
+                    else
+                        m_token--;
                 }
-
-                m_offset++;
             }
         }
 
@@ -212,102 +134,109 @@ namespace pl::core {
         }
     }
 
-    void Preprocessor::handleIfDef() {
-        auto name = getDirectiveValue();
+    void Preprocessor::handleIfDef(unsigned line) {
+        auto token = getDirectiveValue(line);
 
-        if(!isNameValid(name)) {
+        if(!isNameValid(token)) {
             error("Expected identifier after #ifdef");
             return;
         }
 
-        processIfDef(m_defines.contains(name.value()));
+        processIfDef(m_defines.contains( getOptionalValue(token)));
     }
 
-    void Preprocessor::handleIfNDef() {
-        auto name = getDirectiveValue();
+    void Preprocessor::handleIfNDef(unsigned line) {
+        auto token = getDirectiveValue(line);
 
-        if(!isNameValid(name)) {
+        if(!isNameValid(token)) {
             error("Expected identifier after #ifndef");
             return;
         }
 
-        processIfDef(!m_defines.contains(name.value()));
+        processIfDef(!m_defines.contains(getOptionalValue(token)));
     }
 
-    void Preprocessor::handleDefine() {
-        auto name = getDirectiveValue();
+    void Preprocessor::handleDefine(unsigned line) {
+        auto token = getDirectiveValue(line);
 
-        if(!isNameValid(name)) {
+        if(!isNameValid(token)) {
             error("Expected identifier after #define");
             return;
         }
-
-        auto value = getDirectiveValue(true);
-
-        if(!value.has_value()) {
-            error("Expected value after #define");
-            return;
-        }
-        if (m_unDefines.contains(name.value()))
-            m_unDefines.erase(name.value());
-        else if (m_defines.contains(name.value()) && value.value() != m_defines[name.value()].first) {
-            m_replacements[m_defines[name.value()].second] = { name.value(), m_defines[name.value()].first,m_lineNumber };
-            errorAt(Location { m_source, m_lineNumber, 1, name.value().length() },
-                    "Previous definition occurs at line '{}'.", m_defines[name.value()].second);
-            errorAt(Location { m_source, m_defines[name.value()].second, 1, name.value().length() },
-                    "Macro '{}' is redefined in line '{}'.", name.value(), m_lineNumber);
+        auto tokenValue = token.value();
+        auto name = getTokenValue(tokenValue);
+        std::vector<Token> values;
+        auto replacement = getDirectiveValue(line);
+        while (replacement.has_value()) {
+            values.push_back(replacement.value());
+            replacement = getDirectiveValue(line);
         }
 
-        m_defines[name.value()] = { value.value(), m_lineNumber };
+        if (m_defines.contains(name)) {
+            bool isValueNew = m_defines[name] == values;
+            if (isValueNew) {
+                errorAt(values[0].location, "Previous definition occurs at line '{}'.", m_defines[name][0].location.line);
+                errorAt(m_defines[name][0].location, "Macro '{}' is redefined in line '{}'.", name, values[0].location.line);
+                m_defines[name].clear();
+                m_defines[name] = values;
+                removeValue(m_keys, name);
+                m_keys.emplace_back(tokenValue);
+            }
+        } else {
+            m_defines[name] = values;
+            m_keys.emplace_back(tokenValue);
+        }
     }
 
-    void Preprocessor::handleUnDefine() {
-        auto name = getDirectiveValue();
+    void Preprocessor::handleUnDefine(unsigned line) {
+        auto token = getDirectiveValue(line);
 
-        if(!isNameValid(name)) {
+        if(!isNameValid(token)) {
             error("Expected identifier after #undef");
             return;
         }
-
-        if (m_defines.contains(name.value())) {
-            m_replacements[m_defines[name.value()].second] = { name.value(), m_defines[name.value()].first, m_lineNumber };
-            m_defines.erase(name.value());
+        auto name = getOptionalValue(token);
+        if (m_defines.contains(name)) {
+            m_defines.erase(name);
+            removeValue(m_keys, name);
         }
-
-        m_unDefines[name.value()] = m_lineNumber;
     }
 
-    void Preprocessor::handlePragma() {
-        auto key = getDirectiveValue();
+    void Preprocessor::handlePragma(unsigned line) {
+        auto token = getDirectiveValue(line);
 
-        if(!key.has_value()) {
+        if(!token.has_value()) {
             errorDesc("No instruction given in #pragma directive.", "A #pragma directive expects a instruction followed by an optional value in the form of #pragma <instruction> <value>.");
             return;
         }
-
-        auto value = getDirectiveValue(true);
-
-        this->m_pragmas[key.value()].emplace_back(value.value_or(""), m_lineNumber);
+        auto key = getOptionalValue(token);
+        token = getDirectiveValue(line);
+        if (!token.has_value())
+            this->m_pragmas[key].emplace_back("", line);
+        else
+            this->m_pragmas[key].emplace_back(getOptionalValue(token), line);
     }
 
-    void Preprocessor::handleInclude() {
-        const auto includeFile = getDirectiveValue();
+    void Preprocessor::handleInclude(unsigned line) {
+        auto token = getDirectiveValue(line);
+        if (!token.has_value()) {
+            errorDesc("No file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
+            return;
+        }
+        auto includeFile = getOptionalValue(token);
 
-        if (!includeFile.has_value()) {
+        if (includeFile.empty()){
             errorDesc("No file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
             return;
         }
 
-        if (includeFile->starts_with('"') && includeFile->ends_with('"'))
-            ; // Parsed path wrapped in ""
-        else if (includeFile->starts_with('<') && includeFile->ends_with('>'))
-            ; // Parsed path wrapped in <>
-        else {
+        if (!includeFile.starts_with('"') || !includeFile.ends_with('"') ||
+            !includeFile.starts_with('<') || !includeFile.ends_with('>')) {
             errorDesc("Invalid file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
             return;
         }
 
-        const std::string includePath = includeFile->substr(1, includeFile->length() - 2);
+        const std::string includePath = includeFile.substr(1, includeFile.length() - 2);
 
         // determine if we should include this file
         if (this->m_onceIncludedFiles.contains(includePath))
@@ -339,8 +268,6 @@ namespace pl::core {
             return;
         }
 
-        resolved.value()->content = result.unwrap(); // cache result
-
         bool shouldInclude = true;
         if (preprocessor.shouldOnlyIncludeOnce()) {
             auto [iter, added] = this->m_onceIncludedFiles.insert(includePath);
@@ -352,180 +279,101 @@ namespace pl::core {
         std::ranges::copy(preprocessor.m_onceIncludedFiles.begin(), preprocessor.m_onceIncludedFiles.end(), std::inserter(this->m_onceIncludedFiles, this->m_onceIncludedFiles.begin()));
         std::ranges::copy(preprocessor.m_defines.begin(), preprocessor.m_defines.end(), std::inserter(this->m_defines, this->m_defines.begin()));
         std::ranges::copy(preprocessor.m_pragmas.begin(), preprocessor.m_pragmas.end(), std::inserter(this->m_pragmas, this->m_pragmas.begin()));
+        std::ranges::copy(preprocessor.m_keys.begin(), preprocessor.m_keys.end(), std::inserter(this->m_keys, this->m_keys.begin()));
 
         if (shouldInclude) {
             auto content = result.unwrap();
 
-            std::ranges::replace(content.begin(), content.end(), '\n', ' ');
-            std::ranges::replace(content.begin(), content.end(), '\r', ' ');
-
-            content = wolv::util::trim(content);
-
             if (!content.empty())
-                m_output += "/*! DOCS IGNORE ON **/ " + content + " /*! DOCS IGNORE OFF **/";
+                for (auto entry : content) {
+                    if (entry.type == pl::core::Token::Type::Separator) {
+                        if (get<pl::core::Token::Separator>(entry.value) == pl::core::Token::Separator::EndOfProgram)
+                            continue;
+                    }
+                    if (entry.type != pl::core::Token::Type::DocComment)
+                        m_output.push_back(entry);
+                }
         }
     }
 
-    bool Preprocessor::process() {
-        char c = peek();
+    void Preprocessor::process() {
+        unsigned line = m_token->location.line;
 
-        if(c == '\0')
-            return false;
-
-        if (c == '\\') {
-            if (m_inString) {
-                m_output += m_code.substr(m_offset, 2);
-                m_offset += 2;
-                return true;
-            } else
-                return false;
-        }
-
-        if(c == '"') {
-            m_inString = !m_inString;
-        } else if (m_inString) {
-            m_output += peek();
-            m_offset += 1;
-            return true;
-        }
-
-        if(c == '/') { // comment case
-            parseComment();
-        }
-
-        if (peek() == '#' && m_startOfLine && !m_inString) {
-            m_offset += 1;
-
+        if (m_token->type == pl::core::Token::Type::Directive) {
             std::string name = parseDirectiveName();
-
             auto handler = m_directiveHandlers.find(name);
-
-            if(handler == m_directiveHandlers.end()) {
+            if (name == "#endif") {
+                // happens in nested #ifdefs
+                m_token--;
+                return;
+            } else if(handler == m_directiveHandlers.end()) {
                 error("Unknown directive '{}'", name);
-                return true;
-            } else {
-                handler->second(this);
-                if (peek() == '#')
-                    return true;
+                return;
+            } else
+                handler->second(this,line);
+
+        } else if (m_token->type == pl::core::Token::Type::Comment)
+            m_token++;
+        else {
+            std::vector<pl::core::Token> values;
+            std::vector<pl::core::Token> resultValues;
+            values.push_back(*m_token);
+            for (const auto &key: m_keys) {
+                for (const auto &value: values) {
+
+                    if (getTokenValue(value) == getTokenValue(key)) {
+                        for (const auto &newToken: m_defines[getTokenValue(key)])
+                            resultValues.push_back(newToken);
+                    } else
+                        resultValues.push_back(value);
+                }
+                values = resultValues;
+                resultValues.clear();
             }
+            for (const auto &value: values)
+                m_output.push_back(value);
+            m_token++;
         }
-
-        if (m_offset >= m_code.length())
-            return false;
-
-        c = peek();
-
-        if (c == '\n') {
-            m_lineNumber++;
-            m_lineBeginOffset = m_offset;
-            m_startOfLine = true;
-        }
-
-        if (!std::isspace(c))
-            m_startOfLine = false;
-
-
-        m_output += c;
-        m_offset += 1;
-
-        return true;
     }
 
-    void Preprocessor::handleError() {
-        auto message = getDirectiveValue(true);
+    void Preprocessor::handleError(unsigned line) {
+        auto token = getDirectiveValue(line);
 
-        if(message.has_value()) {
-            error(message.value());
+        if(token.has_value()) {
+            auto message = token.value().getFormattedValue();
+            error(message);
         } else {
             error("No message given in #error directive.");
         }
     }
 
-    void Preprocessor::replaceSkippingStrings(std::string &input, const std::string &find, const std::string &replace) {
-        auto parts = wolv::util::splitString(input, "\"");
+    hlp::CompileResult<std::vector<pl::core::Token>> Preprocessor::preprocess(PatternLanguage* runtime, api::Source* source, bool initialRun) {
+        m_source = source;
+        m_source->content = wolv::util::replaceStrings(m_source->content, "\r\n", "\n");
+        m_source->content = wolv::util::replaceStrings(m_source->content, "\r", "\n");
+        m_source->content = wolv::util::replaceStrings(m_source->content, "\t", "    ");
 
-        for (u32 i = 0; i < parts.size(); i += 2) {
-            while (1 < i && i < parts.size() && !parts[i - 1].empty() && parts[i - 1].ends_with('\\')) {
-                parts[i - 1] = wolv::util::combineStrings({parts[i - 1], parts[i]}, "\"");
-                parts.erase(parts.begin() + i);
-            }
-            parts[i] = wolv::util::replaceStrings(parts[i], find, replace);
-        }
-        input = wolv::util::combineStrings(parts, "\"");
-    }
-
-    hlp::CompileResult<std::string> Preprocessor::preprocess(PatternLanguage* runtime, api::Source* source, bool initialRun) {
-        m_startOfLine = true;
-        m_offset      = 0;
-        m_lineNumber  = 1;
-        m_code        = source->content;
-        m_source      = source;
-        m_inString    = false;
-        m_runtime     = runtime;
-        m_lineBeginOffset = 0;
+        m_runtime = runtime;
         m_output.clear();
+
+        auto lexer = runtime->getInternals().lexer.get();
 
         if (initialRun) {
             this->m_onceIncludedFiles.clear();
+            this->m_defines.clear();
+            this->m_keys.clear();
             this->m_onlyIncludeOnce = false;
             this->m_pragmas.clear();
         }
 
-        m_output.reserve(m_code.size());
-
-        while (m_offset < m_code.length()) {
-            if (!process())
-                break;
-        }
-        // defines from included files apply to entire file and can be identified
-        // from a line number of zero.
-        std::vector<std::pair<std::string, std::string >> includedDefines;
-        for (auto define:m_defines) {
-            if (define.second.second != 0)
-                m_replacements[define.second.second] = {define.first, define.second.first, m_lineNumber };
-            else
-                includedDefines.emplace_back(define.first, define.second.first);
-        }
-
-        // Apply defines
-        auto lines = wolv::util::splitString(m_output, "\n");
-        // first defines from included files. order is not important.
-        for (auto &[name, value]: includedDefines) {
-            if (m_output.find(name) != std::string::npos)
-                for (auto line = lines.begin(); line != lines.end(); line++)
-                    replaceSkippingStrings(*line, name, value);
-        }
-
-
-        for (auto &[start, data]: this->m_replacements) {
-            auto [name, value, end] = data;
-            u32 i = 0;
-            end = std::min(end, (u32) lines.size());
-            for ( i = start; i < end; i++) {
-                auto &line = lines[i];
-                if (!line.empty() && line.find(name) != std::string::npos)
-                    replaceSkippingStrings(line, name, value);
-            }
-        }
-
-        m_output = wolv::util::combineStrings(lines, "\n");
-
-
-        // restore doc comments
-        unsigned long long pos = 0;
-        while ((pos = m_output.find((char) 0x80, pos)) != std::string::npos) {
-            if ( pos + 1 < m_output.length()) {
-                unsigned commentIndex = m_output[pos + 1]-1;
-                if (commentIndex < m_docComments.size()) {
-                    auto comment = m_docComments[commentIndex];
-                    auto linesInComment = std::count(comment.begin(), comment.end(), '\n');
-                    m_output.replace(pos, 2 + linesInComment, m_docComments[commentIndex]);
-                    pos += m_docComments[commentIndex].length();
-                } else
-                    break;
-            } else
-                break;
-        }
+        m_result = lexer->lex(m_source);
+        if (m_result.hasErrs())
+            return m_result;
+        m_token = m_result.unwrap().begin();
+        auto tokenEnd = m_result.unwrap().end();
+        m_initialized = true;
+        while (m_token < tokenEnd)
+            process();
 
         // Handle pragmas
         for (const auto &[type, datas] : this->m_pragmas) {
@@ -541,14 +389,12 @@ namespace pl::core {
         }
 
         this->m_defines.clear();
-        this->m_unDefines.clear();
-        this->m_replacements.clear();
 
         return { m_output, collectErrors() };
     }
 
     void Preprocessor::addDefine(const std::string &name, const std::string &value) {
-        this->m_defines[name] = { value, 0 };
+        m_defines[name] = {pl::core::Token { pl::core::Token::Type::Directive, name, location() },pl::core::Token { pl::core::Token::Type::String, value, location() } };
     }
 
     void Preprocessor::addPragmaHandler(const std::string &pragmaType, const api::PragmaHandler &handler) {
@@ -568,12 +414,15 @@ namespace pl::core {
     }
 
     Location Preprocessor::location() {
-        return { m_source, m_lineNumber, (u32) (m_offset - m_lineBeginOffset), 1 };
+        if (isInitialized())
+            return m_token->location;
+        else
+            return {nullptr, 0, 0, 0 };
     }
 
     void Preprocessor::registerDirectiveHandler(const std::string& name, auto memberFunction) {
-        this->m_directiveHandlers[name] = [memberFunction](Preprocessor* preprocessor) {
-            (preprocessor->*memberFunction)();
+        this->m_directiveHandlers[name] = [memberFunction](Preprocessor* preprocessor, unsigned line){
+            (preprocessor->*memberFunction)(line);
         };
     }
 

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -5,6 +5,7 @@
 
 #include <pl/helpers/utils.hpp>
 #include <pl/helpers/concepts.hpp>
+#include <variant>
 
 namespace pl::core {
 
@@ -166,7 +167,9 @@ namespace pl::core {
             case String: return "String";
             case Identifier: return "Identifier";
             case Separator: return "Separator";
+            case Comment: return "Comment";
             case DocComment: return "Doc Comment";
+            case Directive: return "Directive";
         }
 
         return "Unknown";
@@ -325,6 +328,22 @@ namespace pl::core {
 
                                   return "";
                               },
+                              [](const Directive directive) -> std::string  {
+                                  switch (directive) {
+                                      using enum Directive;
+
+                                      case Include: return "#include";
+                                      case Define: return "#define";
+                                      case IfDef: return "#ifdef";
+                                      case IfNDef: return "#ifndef";
+                                      case EndIf: return "#endif";
+                                      case Undef: return "#undef";
+                                      case Pragma: return "#pragma";
+                                      case Error: return "#error";
+                                  }
+
+                                  return "";
+                              },
                               [](const Identifier &identifier) -> std::string  {
                                   return fmt::format("'{}'", identifier.get());
                               },
@@ -334,7 +353,10 @@ namespace pl::core {
                               [](const ValueType valueType) -> std::string  {
                                   return getTypeName(valueType);
                               },
-                              [](const DocComment &docComment) -> std::string {
+                              [](const Comment &comment) -> std::string  {
+                                  return fmt::format("/* {} */", comment.comment);
+                              },
+                              [](const DocComment &docComment) -> std::string  {
                                   if (docComment.global)
                                       return fmt::format("/*! {} */", docComment.comment);
                                   else
@@ -344,7 +366,7 @@ namespace pl::core {
     }
 
     bool Token::operator==(const ValueTypes &other) const {
-        if (this->type == Type::Integer || this->type == Type::Identifier || this->type == Type::String || this->type == Type::DocComment)
+        if (this->type == Type::Integer || this->type == Type::Identifier || this->type == Type::String || this->type == Type::Comment || this->type == Type::DocComment || this->type == Type::Directive)
             return true;
         if (this->type == Type::ValueType) {
             const auto otherValueType = std::get_if<ValueType>(&other);
@@ -387,7 +409,7 @@ namespace pl::core {
         return s_keywords;
     }
 
-    std::map<char, Token>& Token::Seperators() {
+    std::map<char, Token>& Token::Separators() {
         static std::map<char, Token> s_separators;
 
         return s_separators;
@@ -397,6 +419,12 @@ namespace pl::core {
         static std::map<std::string_view, Token> s_types;
 
         return s_types;
+    }
+
+    std::map<std::string_view, Token> &Token::Directives() {
+        static std::map<std::string_view, Token> s_directives;
+
+        return s_directives;
     }
 
 }

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -421,7 +421,7 @@ namespace pl::core {
         return s_types;
     }
 
-    std::map<std::string_view, Token> &Token::Directives() {
+    std::map<std::string_view, Token>& Token::Directives() {
         static std::map<std::string_view, Token> s_directives;
 
         return s_directives;

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -79,7 +79,7 @@ namespace pl {
         if (!parserErrors.empty())
             this->m_compileErrors = std::move(parserErrors);
 
-        if(!ast.has_value() || ast->empty())
+        if (!ast.has_value() || ast->empty())
             return std::nullopt;
 
         auto [validated, validatorErrors] = this->m_internals.validator->validate(ast.value());

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -50,7 +50,7 @@ namespace pl {
         this->m_running.exchange(other.m_running.load());
     }
 
-    std::optional<api::Source*> PatternLanguage::preprocessString(const std::string& code, const std::string& source) {
+    [[nodiscard]] std::optional<std::vector<pl::core::Token>> PatternLanguage::preprocessString(const std::string& code, const std::string& source) {
         this->reset();
 
         auto internalSource = addVirtualSource(code, source); // add virtual source to file resolver
@@ -71,7 +71,7 @@ namespace pl {
     }
 
     std::optional<std::vector<std::shared_ptr<core::ast::ASTNode>>> PatternLanguage::parseString(const std::string &code, const std::string &source) {
-        auto tokens = this->lexString(code, source);
+        auto tokens = this->preprocessString(code, source);
         if (!tokens.has_value() || tokens->empty())
             return std::nullopt;
 

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -55,42 +55,34 @@ namespace pl {
 
         auto internalSource = addVirtualSource(code, source); // add virtual source to file resolver
 
-        auto [preprocessedCode, preprocessorErrors] = this->m_internals.preprocessor->preprocess(this, internalSource);
-        if (!preprocessorErrors.empty()) {
+        auto [tokens, preprocessorErrors] = this->m_internals.preprocessor->preprocess(this, internalSource, true);
+        if (!preprocessorErrors.empty())
             this->m_compileErrors = std::move(preprocessorErrors);
+        if (!tokens.has_value() || tokens->empty())
             return std::nullopt;
-        }
-
-        internalSource->content = std::move(preprocessedCode.value()); // update source object with preprocessed code
-
-        auto [tokens, lexerErrors] = this->m_internals.lexer->lex(internalSource);
-
-        if (!lexerErrors.empty()) {
-            this->m_compileErrors = std::move(lexerErrors);
-            return std::nullopt;
-        }
 
         return tokens;
     }
 
     std::optional<std::vector<std::shared_ptr<core::ast::ASTNode>>> PatternLanguage::parseString(const std::string &code, const std::string &source) {
         auto tokens = this->lexString(code, source);
-        if (!tokens.has_value()) {
+        if (!tokens.has_value() || tokens->empty())
             return std::nullopt;
-        }
 
         auto [ast, parserErrors] = this->m_internals.parser->parse(tokens.value());
-        if (!parserErrors.empty()) {
+        if (!parserErrors.empty())
             this->m_compileErrors = std::move(parserErrors);
-            return std::nullopt;
-        }
 
-        auto [validated, validatorErrors] = this->m_internals.validator->validate(*ast);
-        wolv::util::unused(validated);
-        if (!validatorErrors.empty()) {
-            this->m_compileErrors = std::move(validatorErrors);
+        if(!ast.has_value() || ast->empty())
             return std::nullopt;
-        }
+
+        auto [validated, validatorErrors] = this->m_internals.validator->validate(ast.value());
+        wolv::util::unused(validated);
+        if (!validatorErrors.empty())
+            this->m_compileErrors = std::move(validatorErrors);
+
+        if (ast->empty() || !ast.has_value())
+            return std::nullopt;
 
         return ast;
     }


### PR DESCRIPTION
feat: added #undef preprocessor directive.  
fix: missing char in message of lexer.
fix: preprocessor no longer does replacements inside strings or doc comments. Also defines are only applied after their position in the code instead of globally. Redefinition of macros is allowed but a warning message is issued. Defines are only allowed to use non-empty and valid identifiers as macro names. 
fix: problem that directives without complete syntax did not generate error messages. (as in #define with nothing after last e)
fix: some combinations  of comments were not handled correctly for example /**/ was parsed as a beginning doc comment.
fix: nested #ifdef directives were not parsed correctly producing errors elsewhere.
fix: The deletion of comments by preprocessor resulted in wrong column numbers being displayed in error messages.
fix: two consecutive directives with no space between them caused the failure to parse the second directive.

Needs work: if an error occurs inside an included file, its location is reported as it is in the preprocessed code. Since the entire file is stored in a single line to preserve line numbers in including pattern this results in making it hard to track the error. The reported column number needs to be converted to the correct position of the error in the file. Better yet would be to add references to the file being included so they can be parsed in their original form and generate better errors.

The code modifications try to adhere to the spirit of the recent code refactoring.  Adding new code is chosen over modifying existing code whenever possible within reasonable limits. Please review at your earliest convenience.