### PR TITLE
Fixes for unit tests on github

### DIFF
--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -32,8 +32,6 @@ namespace pl::core {
         void removePragmaHandler(const std::string &pragmaType);
         void removeDirectiveHandler(const Token::Directive &directiveType);
 
-        std::optional<Token> getDirectiveValue(u32 line);
-
         [[nodiscard]] bool shouldOnlyIncludeOnce() const {
             return this->m_onlyIncludeOnce;
         }
@@ -50,7 +48,7 @@ namespace pl::core {
         Preprocessor(const Preprocessor &);
         bool eof();
         Location location() override;
-
+        void removeKey(const Token &token);
         // directive handlers
         void handleIfDef(u32 line);
         void handleIfNDef(u32 line);

--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -48,7 +48,7 @@ namespace pl::core {
 
     private:
         Preprocessor(const Preprocessor &);
-
+        bool eof();
         Location location() override;
 
         // directive handlers
@@ -79,7 +79,8 @@ namespace pl::core {
         std::vector<Token> m_keys;
         std::atomic<bool> m_initialized = false;
         std::vector<Token>::iterator m_token;
-        hlp::CompileResult<std::vector<Token>> m_result;
+        std::vector<err::CompileError> m_errors;
+        std::vector<Token> m_result;
         std::vector<Token> m_output;
 
         api::Source* m_source = nullptr;

--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -130,20 +130,12 @@ namespace pl::core {
         std::string name;
         auto token = *m_token;
         if (m_token->location.line != line || tokenIdentifier == nullptr || !isValidIdentifier(token)) {
-            error("Expected identifier after #ifdef");
+            error("Expected identifier after #define");
             return;
         } else {
             name = tokenIdentifier->get();
         }
         m_token++;
-
-        auto *identifier = std::get_if<Token::Identifier>(&m_token->value);
-        if (identifier != nullptr)
-            name = identifier->get();
-        else {
-            error("Expected identifier after #define");
-            return;
-        }
 
         std::vector<Token> values;
         while (m_token->location.line == line) {
@@ -199,9 +191,8 @@ namespace pl::core {
         else {
             std::string value = tokenLiteral->toString(false);
             this->m_pragmas[key].emplace_back(value, line);
+            m_token++;
         }
-        m_token++;
-
     }
 
     void Preprocessor::handleInclude(u32 line) {
@@ -305,8 +296,8 @@ namespace pl::core {
                 for (const auto &value: values) {
                     const Token::Identifier *valueIdentifier = std::get_if<Token::Identifier>(&value.value);
                     if (valueIdentifier == nullptr)
-                        continue;
-                   if (valueIdentifier->get() == keyIdentifier->get() ) {
+                        resultValues.push_back(value);
+                   else if (valueIdentifier->get() == keyIdentifier->get() ) {
                         for (const auto &newToken: m_defines[keyIdentifier->get()])
                             resultValues.push_back(newToken);
                     } else

--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -62,7 +62,7 @@ namespace pl::core {
         return getTokenValue(token.value());
     }
 
-    static bool isNameValid(const std::optional<pl::core::Token> &token) {
+    static bool isNameValid(const std::optional<Token> &token) {
         if (!token.has_value())
             return false;
         auto name = getOptionalValue(token);
@@ -76,7 +76,7 @@ namespace pl::core {
         return true;
     }
 
-    bool operator==(const std::vector<pl::core::Token> &a, const std::vector<pl::core::Token> &b) {
+    bool operator==(const std::vector<Token>& a, const std::vector<Token>& b) {
         if (a.size() != b.size())
             return false;
         for (u32 i = 0; i < a.size(); i++)
@@ -85,15 +85,15 @@ namespace pl::core {
         return true;
     }
 
-    void removeValue(std::vector<pl::core::Token> &vec,const std::string &name) {
+    void removeValue(std::vector<Token> &vec,const std::string &name) {
         for (u32 i = 0; i < vec.size(); i++)
             if (getTokenValue(vec[i]) == name)
                 vec.erase(vec.begin() + i);
     }
 
-    std::optional<pl::core::Token> Preprocessor::getDirectiveValue(u32 line) {
-        const pl::core::Token &token = *m_token;
-        if (m_token->location.line != line || m_token >= m_result.unwrap().end())
+    std::optional<Token> Preprocessor::getDirectiveValue(u32 line) {
+        const Token &token = *m_token;
+        if (m_token->location.line != line || eof())
             return std::nullopt;
         m_token++;
         return token;
@@ -103,31 +103,19 @@ namespace pl::core {
         // find the next #endif
         const Location start = location();
         u32 depth = 1;
-        while (m_token != m_result.unwrap().end() && depth > 0) {
-            if (m_token->type == pl::core::Token::Type::Directive) {
-                Token::Directive directive = get<Token::Directive>(m_token->value);
-                if (directive == pl::core::Token::Directive::EndIf) {
-                    m_token++;
-                    depth--;
-                }
+        while(!eof() && depth > 0) {
+            if (Token::Directive *directive = std::get_if<Token::Directive>(&m_token->value); directive != nullptr && *directive == Token::Directive::EndIf) {
+                depth--;
+                m_token++;
+                continue;
             }
-            if(add) process();
-            else {
-                if (m_token->type == pl::core::Token::Type::Directive) {
-                    Token::Directive directive = get<Token::Directive>(m_token->value);
-                    if (directive == pl::core::Token::Directive::IfDef ||
-                        directive == pl::core::Token::Directive::IfNDef) {
-                        depth++;
-                        m_token++;
-                    } else if (directive == pl::core::Token::Directive::EndIf) {
-                        if (depth > 0) {
-                            m_token++;
-                            depth--;
-                        }
-                    }
-                } else {
-                    m_token++;
-                }
+            if(add) {
+                process();
+            } else {
+                if (Token::Directive *directive = std::get_if<Token::Directive>(&m_token->value);directive != nullptr &&
+                    (*directive == Token::Directive::IfDef || *directive == Token::Directive::IfNDef))
+                    depth++;
+                m_token++;
             }
         }
 
@@ -178,8 +166,8 @@ namespace pl::core {
         }
 
         if (m_defines.contains(name)) {
-            bool isValueNew = m_defines[name] == values;
-            if (isValueNew) {
+            bool isValueSame = m_defines[name] == values;
+            if (!isValueSame) {
                 errorAt(values[0].location, "Previous definition occurs at line '{}'.", m_defines[name][0].location.line);
                 errorAt(m_defines[name][0].location, "Macro '{}' is redefined in line '{}'.", name, values[0].location.line);
                 m_defines[name].clear();
@@ -244,7 +232,6 @@ namespace pl::core {
         }
 
         const std::string includePath = includeFile.substr(1, includeFile.length() - 2);
-
         // determine if we should include this file
         if (this->m_onceIncludedFiles.contains(includePath))
             return;
@@ -293,11 +280,11 @@ namespace pl::core {
 
             if (!content.empty())
                 for (auto entry : content) {
-                    if (entry.type == pl::core::Token::Type::Separator) {
-                        if (get<pl::core::Token::Separator>(entry.value) == pl::core::Token::Separator::EndOfProgram)
+                    if (entry.type == Token::Type::Separator) {
+                        if (get<Token::Separator>(entry.value) == Token::Separator::EndOfProgram)
                             continue;
                     }
-                    if (entry.type != pl::core::Token::Type::DocComment)
+                    if (entry.type != Token::Type::DocComment)
                         m_output.push_back(entry);
                 }
         }
@@ -306,13 +293,9 @@ namespace pl::core {
     void Preprocessor::process() {
         u32 line = m_token->location.line;
 
-        if (m_token->type == Token::Type::Directive) {
-            Token::Directive directive = get<Token::Directive>(m_token->value);
-            auto handler = m_directiveHandlers.find(directive);
-            if (directive == Token::Directive::EndIf) {
-                // Happens in nested #ifdefs
-                return;
-            } else if(handler == m_directiveHandlers.end()) {
+        if (Token::Directive *directive = std::get_if<Token::Directive>(&m_token->value); directive != nullptr ) {
+            auto handler = m_directiveHandlers.find(*directive);
+            if(handler == m_directiveHandlers.end()) {
                 error("Unknown directive '{}'", m_token->getFormattedValue());
                 m_token++;
                 return;
@@ -321,11 +304,11 @@ namespace pl::core {
                 handler->second(this, line);
             }
 
-        } else if (m_token->type == pl::core::Token::Type::Comment)
+        } else if (m_token->type == Token::Type::Comment)
             m_token++;
         else {
-            std::vector<pl::core::Token> values;
-            std::vector<pl::core::Token> resultValues;
+            std::vector<Token> values;
+            std::vector<Token> resultValues;
             values.push_back(*m_token);
             for (const auto &key: m_keys) {
                 for (const auto &value: values) {
@@ -358,11 +341,17 @@ namespace pl::core {
         }
     }
 
+    bool Preprocessor::eof() {
+        return m_token == m_result.end();
+    }
+
     hlp::CompileResult<std::vector<Token>> Preprocessor::preprocess(PatternLanguage* runtime, api::Source* source, bool initialRun) {
         m_source = source;
         m_source->content = wolv::util::replaceStrings(m_source->content, "\r\n", "\n");
         m_source->content = wolv::util::replaceStrings(m_source->content, "\r", "\n");
         m_source->content = wolv::util::replaceStrings(m_source->content, "\t", "    ");
+        while (m_source->content.ends_with('\n'))
+            m_source->content.pop_back();
 
         m_runtime = runtime;
         m_output.clear();
@@ -376,17 +365,26 @@ namespace pl::core {
             this->m_keys.clear();
             this->m_onlyIncludeOnce = false;
             this->m_pragmas.clear();
-
+            for (const auto& [name, value] : m_runtime->getDefines()) {
+                addDefine(name, value);
+            }
+            for (const auto& [name, handler]: m_runtime->getPragmas()) {
+                addPragmaHandler(name, handler);
+            }
         }
 
-        m_result = lexer->lex(m_source);
-        if (m_result.hasErrs())
-            return m_result;
-        m_token = m_result.unwrap().begin();
-        auto tokenEnd = m_result.unwrap().end();
+        auto [result,errors] = lexer->lex(m_source);
+        if (result.has_value())
+            m_result = std::move(result.value());
+        else
+            return { std::nullopt, errors };
+        if (!errors.empty())
+            m_errors = std::move(errors);
+        else
+            m_errors.clear();
+
         m_initialized = true;
-        while (m_token < tokenEnd)
-            process();
+        while (!eof())         process();
 
         // Handle pragmas
         for (const auto &[type, datas] : this->m_pragmas) {

--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -34,11 +34,8 @@ namespace pl::core {
         this->m_onlyIncludeOnce = false;
         this->m_pragmaHandlers = other.m_pragmaHandlers;
         this->m_directiveHandlers = other.m_directiveHandlers;
-        this->m_runtime = other.m_runtime;
         this->m_keys = other.m_keys;
         this->m_initialized = false;
-        this->m_source = other.m_source;
-        this->m_output.clear();
 
         // need to update, because old handler points to old `this`
         this->addPragmaHandler("once", [this](PatternLanguage&, const std::string &value) {
@@ -48,53 +45,33 @@ namespace pl::core {
         });
     }
 
-    std::string getTokenValue(const Token &token) {
-        auto identifier = token.getFormattedValue();
-        if (identifier.length() > 1 )
-            return identifier.substr(1, identifier.length() - 2);
-        else
-            return identifier;
-    }
-
-    std::string getOptionalValue(std::optional<Token> token) {
-        if (!token.has_value())
-            return "";
-        return getTokenValue(token.value());
-    }
-
-    static bool isNameValid(const std::optional<Token> &token) {
+    static bool isValidIdentifier(const std::optional<Token> &token) {
         if (!token.has_value())
             return false;
-        auto name = getOptionalValue(token);
+        const Token::Identifier *identifier = std::get_if<Token::Identifier>(&token->value);
+        auto name = identifier->get();
         if (name.empty())
             return false;
-
         return std::ranges::all_of(name, [](char c) {
             return std::isalnum(c) || c == '_';
         });
+
+        return true;
     }
 
     bool operator==(const std::vector<Token>& a, const std::vector<Token>& b) {
         if (a.size() != b.size())
             return false;
         for (u32 i = 0; i < a.size(); i++)
-            if (getTokenValue(a[i]) != getTokenValue(b[i]))
+            if (a[i].type != b[i].type || a[i].value != b[i].value || a[i].location.line != b[i].location.line || a[i].location.column != b[i].location.column || a[i].location.length != b[i].location.length || a[i].location.source != b[i].location.source)
                 return false;
         return true;
     }
 
-    void removeValue(std::vector<Token> &vec,const std::string &name) {
-        for (u32 i = 0; i < vec.size(); i++)
-            if (getTokenValue(vec[i]) == name)
-                vec.erase(vec.begin() + i);
-    }
-
-    std::optional<Token> Preprocessor::getDirectiveValue(u32 line) {
-        const Token &token = *m_token;
-        if (m_token->location.line != line || eof())
-            return std::nullopt;
-        m_token++;
-        return token;
+    void Preprocessor::removeKey(const Token &token) {
+        for (u32 i = 0; i < m_keys.size(); i++)
+            if (m_keys[i].value == token.value)
+                m_keys.erase(m_keys.begin() + i);
     }
 
     void Preprocessor::processIfDef(const bool add) {
@@ -102,7 +79,7 @@ namespace pl::core {
         const Location start = location();
         u32 depth = 1;
         while(!eof() && depth > 0) {
-            if (Token::Directive *directive = std::get_if<Token::Directive>(&m_token->value); directive != nullptr && *directive == Token::Directive::EndIf) {
+            if (auto *directive = std::get_if<Token::Directive>(&m_token->value); directive != nullptr && *directive == Token::Directive::EndIf) {
                 depth--;
                 m_token++;
                 continue;
@@ -110,7 +87,7 @@ namespace pl::core {
             if(add) {
                 process();
             } else {
-                if (Token::Directive *directive = std::get_if<Token::Directive>(&m_token->value);directive != nullptr &&
+                if (auto *directive = std::get_if<Token::Directive>(&m_token->value);directive != nullptr &&
                     (*directive == Token::Directive::IfDef || *directive == Token::Directive::IfNDef))
                     depth++;
                 m_token++;
@@ -124,100 +101,117 @@ namespace pl::core {
     }
 
     void Preprocessor::handleIfDef(u32 line) {
-        auto token = getDirectiveValue(line);
 
-        if (!isNameValid(token)) {
+        auto *identifier = std::get_if<Token::Identifier>(&m_token->value);
+        auto token = *m_token;
+        if (m_token->location.line != line || identifier == nullptr || !isValidIdentifier(token)) {
             error("Expected identifier after #ifdef");
             return;
         }
-
-        processIfDef(m_defines.contains( getOptionalValue(token)));
+        m_token++;
+        processIfDef(m_defines.contains(identifier->get()));
     }
 
     void Preprocessor::handleIfNDef(u32 line) {
-        auto token = getDirectiveValue(line);
 
-        if (!isNameValid(token)) {
-            error("Expected identifier after #ifndef");
+        auto *identifier = std::get_if<Token::Identifier>(&m_token->value);
+        auto token = *m_token;
+        if (m_token->location.line != line || identifier == nullptr || !isValidIdentifier(token)) {
+            error("Expected identifier after #ifdef");
             return;
         }
-
-        processIfDef(!m_defines.contains(getOptionalValue(token)));
+        m_token++;
+        processIfDef(!m_defines.contains(identifier->get()));
     }
 
     void Preprocessor::handleDefine(u32 line) {
-        auto token = getDirectiveValue(line);
 
-        if (!isNameValid(token)) {
+        auto *tokenIdentifier = std::get_if<Token::Identifier>(&m_token->value);
+        std::string name;
+        auto token = *m_token;
+        if (m_token->location.line != line || tokenIdentifier == nullptr || !isValidIdentifier(token)) {
+            error("Expected identifier after #ifdef");
+            return;
+        } else {
+            name = tokenIdentifier->get();
+        }
+        m_token++;
+
+        auto *identifier = std::get_if<Token::Identifier>(&m_token->value);
+        if (identifier != nullptr)
+            name = identifier->get();
+        else {
             error("Expected identifier after #define");
             return;
         }
 
-        auto tokenValue = token.value();
-        auto name = getTokenValue(tokenValue);
-
         std::vector<Token> values;
-        auto replacement = getDirectiveValue(line);
-        while (replacement.has_value()) {
-            values.push_back(replacement.value());
-            replacement = getDirectiveValue(line);
+        while (m_token->location.line == line) {
+            values.push_back(*m_token);
+            m_token++;
         }
 
         if (m_defines.contains(name)) {
             bool isValueSame = m_defines[name] == values;
-            if (!isValueSame) {
+            if (isValueSame) {
                 errorAt(values[0].location, "Previous definition occurs at line '{}'.", m_defines[name][0].location.line);
                 errorAt(m_defines[name][0].location, "Macro '{}' is redefined in line '{}'.", name, values[0].location.line);
                 m_defines[name].clear();
                 m_defines[name] = values;
-                removeValue(m_keys, name);
-                m_keys.emplace_back(tokenValue);
+                removeKey(token);
+                m_keys.emplace_back(token);
             }
         } else {
             m_defines[name] = values;
-            m_keys.emplace_back(tokenValue);
+            m_keys.emplace_back(token);
         }
     }
 
     void Preprocessor::handleUnDefine(u32 line) {
-        auto token = getDirectiveValue(line);
 
-        if(!isNameValid(token)) {
-            error("Expected identifier after #undef");
+        auto *tokenIdentifier = std::get_if<Token::Identifier>(&m_token->value);
+        auto token = *m_token;
+        std::string name;
+        if (m_token->location.line != line || tokenIdentifier == nullptr || !isValidIdentifier(token)) {
+            error("Expected identifier after #ifdef");
             return;
+        } else {
+            name = tokenIdentifier->get();
         }
-
-        auto name = getOptionalValue(token);
+        m_token++;
         if (m_defines.contains(name)) {
             m_defines.erase(name);
-            removeValue(m_keys, name);
+            removeKey(token);
         }
     }
 
     void Preprocessor::handlePragma(u32 line) {
-        auto token = getDirectiveValue(line);
-
-        if (!token.has_value()) {
+        auto *tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
+        if (tokenLiteral == nullptr) {
             errorDesc("No instruction given in #pragma directive.", "A #pragma directive expects a instruction followed by an optional value in the form of #pragma <instruction> <value>.");
             return;
         }
-
-        auto key = getOptionalValue(token);
-        token = getDirectiveValue(line);
-        if (!token.has_value())
+        m_token++;
+        auto key = tokenLiteral->toString(false);
+        tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
+        if (m_token->location.line != line || tokenLiteral == nullptr)
             this->m_pragmas[key].emplace_back("", line);
-        else
-            this->m_pragmas[key].emplace_back(getOptionalValue(token), line);
+        else {
+            std::string value = tokenLiteral->toString(false);
+            this->m_pragmas[key].emplace_back(value, line);
+        }
+        m_token++;
+
     }
 
     void Preprocessor::handleInclude(u32 line) {
-        auto token = getDirectiveValue(line);
-        if (!token.has_value()) {
+        auto *tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
+        if (tokenLiteral == nullptr || m_token->location.line != line) {
             errorDesc("No file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
             return;
         }
-
-        auto includeFile = getOptionalValue(token);
+        m_token++;
+        auto includeFile =  tokenLiteral->toString(false);
 
         if (includeFile.empty()){
             errorDesc("No file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
@@ -278,10 +272,8 @@ namespace pl::core {
 
             if (!content.empty())
                 for (auto entry : content) {
-                    if (entry.type == Token::Type::Separator) {
-                        if (get<Token::Separator>(entry.value) == Token::Separator::EndOfProgram)
-                            continue;
-                    }
+                    if (auto *separator = std::get_if<Token::Separator>(&entry.value); separator != nullptr && *separator == Token::Separator::EndOfProgram)
+                        continue;
                     if (entry.type != Token::Type::DocComment)
                         m_output.push_back(entry);
                 }
@@ -291,7 +283,7 @@ namespace pl::core {
     void Preprocessor::process() {
         u32 line = m_token->location.line;
 
-        if (Token::Directive *directive = std::get_if<Token::Directive>(&m_token->value); directive != nullptr ) {
+        if (auto *directive = std::get_if<Token::Directive>(&m_token->value); directive != nullptr ) {
             auto handler = m_directiveHandlers.find(*directive);
             if(handler == m_directiveHandlers.end()) {
                 error("Unknown directive '{}'", m_token->getFormattedValue());
@@ -309,10 +301,13 @@ namespace pl::core {
             std::vector<Token> resultValues;
             values.push_back(*m_token);
             for (const auto &key: m_keys) {
+                const Token::Identifier *keyIdentifier = std::get_if<Token::Identifier>(&key.value);
                 for (const auto &value: values) {
-
-                    if (getTokenValue(value) == getTokenValue(key)) {
-                        for (const auto &newToken: m_defines[getTokenValue(key)])
+                    const Token::Identifier *valueIdentifier = std::get_if<Token::Identifier>(&value.value);
+                    if (valueIdentifier == nullptr)
+                        continue;
+                   if (valueIdentifier->get() == keyIdentifier->get() ) {
+                        for (const auto &newToken: m_defines[keyIdentifier->get()])
                             resultValues.push_back(newToken);
                     } else
                         resultValues.push_back(value);
@@ -320,19 +315,25 @@ namespace pl::core {
                 values = resultValues;
                 resultValues.clear();
             }
-
             for (const auto &value: values)
                 m_output.push_back(value);
             m_token++;
         }
-        return;
     }
 
     void Preprocessor::handleError(u32 line) {
-        auto token = getDirectiveValue(line);
+        auto *tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
 
-        if (token.has_value()) {
-            auto message = token.value().getFormattedValue();
+        auto token =*m_token;
+
+        if(tokenLiteral != nullptr && m_token->location.line == line) {
+            auto message = tokenLiteral->toString(false);
+            m_token++;
+            tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
+            if (tokenLiteral != nullptr && m_token->location.line == line) {
+                message += " " + tokenLiteral->toString(false);
+                m_token++;
+            }
             error(message);
         } else {
             error("No message given in #error directive.");
@@ -393,9 +394,9 @@ namespace pl::core {
                 const auto &[value, line] = data;
 
                 if (this->m_pragmaHandlers.contains(type)) {
-                    if (!this->m_pragmaHandlers[type](*runtime, value))
+                    if (!this->m_pragmaHandlers[type](*m_runtime, value))
                         errorAt(Location { m_source, line, 1, value.length() },
-                                 "Value '{}' cannot be used with the '{}' pragma directive.", value, type);
+                                "Value '{}' cannot be used with the '{}' pragma directive.", value, type);
                 }
             }
         }
@@ -406,14 +407,9 @@ namespace pl::core {
     }
 
     void Preprocessor::addDefine(const std::string &name, const std::string &value) {
-        m_defines[name] = { 
-            pl::core::Token { 
-                pl::core::Token::Type::Directive, 
-                name, 
-                location() 
-            }, 
-            pl::core::Token { 
-                pl::core::Token::Type::String, 
+        m_defines[name] = {
+            Token {
+                Token::Type::String,
                 value, 
                 location() 
             } 

--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -384,7 +384,10 @@ namespace pl::core {
             m_errors.clear();
 
         m_initialized = true;
-        while (!eof())         process();
+        m_token = m_result.begin();
+
+        while (!eof())
+            process();
 
         // Handle pragmas
         for (const auto &[type, datas] : this->m_pragmas) {


### PR DESCRIPTION
All code that was probable cause to the failure was replaced with safer code. changes include:

- There was a problem with add_defines code that created extra tokens using the name of the definition. 
- there was a return with no value on a function that returned void. 
- Instead of using functions to consume tokens, the directive handlers do the token consumption themselves. 
- the preprocessor copy constructor was copying members that were going to be overwritten during preprocessing. 
- explicit type declarations were changed to auto per clang tidy suggestion.

Any of these changes may  have been the cause, i didn't test to see which one caused it.