### PR TITLE
improv: updates for full syntax highlighting and to allow interactive compilation errors marked using squiggles under the location of the errors which show the message when hovered.

### DIFF
--- a/lib/include/pl/core/lexer.hpp
+++ b/lib/include/pl/core/lexer.hpp
@@ -56,5 +56,6 @@ namespace pl::core {
         size_t m_cursor = 0;
         u32 m_line = 0;
         u32 m_lineBegin = 0;
+        u32 m_errorLength;
     };
 }

--- a/lib/include/pl/core/location.hpp
+++ b/lib/include/pl/core/location.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pl/helpers/types.hpp>
+#include <optional>
 
 namespace pl::api {
     struct Source;
@@ -16,6 +17,40 @@ namespace pl::core {
 
         constexpr static Location Empty() {
             return { nullptr, 0, 0, 0 };
+        }
+
+        bool operator==(const Location& other) const {
+            if (source != other.source)
+                return false;
+            return line == other.line && column == other.column;
+        }
+
+        bool operator!=(const Location& other) const {
+            return !(*this == other);
+        }
+
+        std::optional<bool> operator<(const Location& other) const {
+            if (source != other.source)
+                return std::nullopt;
+            return  (line < other.line) || ( line == other.line && column < other.column);
+        }
+
+        std::optional<bool> operator>(const Location& other) const {
+            if (source != other.source)
+                return std::nullopt;
+            return  (line > other.line) || (line == other.line && column > other.column);
+        }
+
+        std::optional<bool> operator<=(const Location& other) const {
+            if (*this == other)
+                return true;
+            return (*this < other);
+        }
+
+        std::optional<bool> operator>=(const Location& other) const {
+            if (*this == other)
+                return true;
+            return (*this > other);
         }
 
     };

--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -19,7 +19,10 @@ namespace pl::core {
 
     class Preprocessor : public err::ErrorCollector {
     public:
-
+        struct ExcludedLocation {
+            bool isExcluded;
+            Location location;
+        };
         Preprocessor();
 
         ~Preprocessor() override = default;
@@ -31,6 +34,17 @@ namespace pl::core {
         void addDirectiveHandler(const Token::Directive &directiveType, const api::DirectiveHandler &handler);
         void removePragmaHandler(const std::string &pragmaType);
         void removeDirectiveHandler(const Token::Directive &directiveType);
+        void validateExcludedLocations();
+        void appendExcludedLocation(const ExcludedLocation &location);
+        void validateOutput();
+
+        [[nodiscard]] auto getExcludedLocations() const {
+            return m_excludedLocations;
+        }
+
+        [[nodiscard]] auto getResult() const {
+            return this->m_result;
+        }
 
         [[nodiscard]] bool shouldOnlyIncludeOnce() const {
             return this->m_onlyIncludeOnce;
@@ -68,6 +82,7 @@ namespace pl::core {
 
         std::unordered_map<std::string, std::vector<Token>> m_defines;
         std::unordered_map<std::string, std::vector<std::pair<std::string, u32>>> m_pragmas;
+        std::vector<ExcludedLocation> m_excludedLocations;
 
         std::set<std::string> m_onceIncludedFiles;
 

--- a/lib/include/pl/core/token.hpp
+++ b/lib/include/pl/core/token.hpp
@@ -168,28 +168,57 @@ namespace pl::core {
         };
 
         struct Identifier {
-            explicit Identifier(std::string identifier) : m_identifier(std::move(identifier)) { }
+            enum class IdentifierType {
+                Unknown,
+                FunctionUnknown,
+                MemberUnknown,
+                UDT,
+                PatternVariable,
+                PatternLocalVariable,
+                PatternPlacedVariable,
+                FunctionVariable,
+                FunctionParameter,
+                PlacedVariable,
+                GlobalVariable,
+                Function,
+                Macro,
+                NameSpace,
+                Typedef,
+                Keyword,
+                BuiltInType,
+                Attribute,
+                Directive
+            };
+
+            explicit Identifier(std::string identifier="", IdentifierType identifierType = IdentifierType::Unknown) : m_identifier(std::move(identifier)), m_type(identifierType) { }
 
             [[nodiscard]] const std::string &get() const { return this->m_identifier; }
+            [[nodiscard]] IdentifierType getType() const { return this->m_type; }
+            void setType(IdentifierType idtype) { this->m_type = idtype; }
+
 
             bool operator==(const Identifier &) const  = default;
 
         private:
             std::string m_identifier;
+            IdentifierType m_type;
         };
 
         struct DocComment {
             bool global;
+            bool singleLine;
             std::string comment;
 
             constexpr bool operator==(const DocComment &) const = default;
         };
 
         struct Comment {
+            bool singleLine;
             std::string comment;
 
             constexpr bool operator==(const Comment &) const = default;
         };
+
 
         struct Literal : std::variant<char, bool, u128, i128, double, std::string, std::shared_ptr<ptrn::Pattern>> {
             using variant::variant;

--- a/lib/include/pl/core/tokens.hpp
+++ b/lib/include/pl/core/tokens.hpp
@@ -72,12 +72,12 @@ namespace pl::core::tkn {
             return makeToken(core::Token::Type::String, Token::Literal(value));
         }
 
-        inline Token makeDocComment(bool global, const std::string &value) {
-            return { core::Token::Type::DocComment, Token::DocComment { global, value }, Location::Empty() };
+        inline Token makeDocComment(bool global,bool singleLine, const std::string &value) {
+            return { Token::Type::DocComment, Token::DocComment { global, singleLine, value }, Location::Empty() };
         }
 
-        inline Token makeComment(const std::string &value) {
-            return { core::Token::Type::Comment, Token::Comment { value }, Location::Empty() };
+        inline Token makeComment(bool singleLine, const std::string &value) {
+            return { Token::Type::Comment, Token::Comment { singleLine,  value }, Location::Empty() };
         }
 
         const auto Identifier = makeToken(core::Token::Type::Identifier, { });


### PR DESCRIPTION
This is the pattern language side of the improvements only. The rest will be submitted to another PR in the ImHex repo. Although the full implementation of the features needs both sides each side can be applied independently to the current master branches of each repo without compile or runtime errors and pass all unit tests, but some of the previous implementation aspects of the features added may not work correctly or at all.

The following changes are included and some bugs were fixed:

- Syntax highlights are created using the lexer and the parser and it is completely independent of the text editor. The coloring itself is handled by the editor using a simple interface that is documented using doc comments. The syntax information is collected by the pattern language viewer and updated as the code is being typed which requires the creation of background tasks where the code is lexed and parsed. If errors are generated during lex-parsing they are used to mark the code using under-squiggles and the content of the errors pops up when the affected area is hovered. 
- Added error size detection and display to the errors raised by the lexer so that source code can be properly marked.
- Added comparison operators to Location values to facilitate algorithms.
- Preprocessor now handles ifdefs using excluded locations which are positions in the code that mark the beggining and the end of excluded code.
- The token classes for comments and identifiers now include fields to help identify their different types. For all comments a singleLine boolean and for doc comments an isGlobal boolean. Due to the high number of identifier types an enumeration was created to help classification.
- Excessive and unneeded scope qualifiers were removed when found.
- Numeric literals that included a sign (-1, or 1e-4f) were not accepted by the lexer.
- Comments were not parsed correctly by lexer. It skipped too many input chars.
- The parser has an active role in identifier classification. It does this by adding the appropiate identifier type value to the token when it knows for certain what the type is. For the other cases it adds an approximation (eg function vs member) or just makes the type unknown. Those need to be resolved so that highlighting can be done.
- The preprocessor sets the identifier types to all Macro variables defined and/or used.