### PR TITLE
Improv: last changes for syntax highlighter done in view_patternEditor

### DIFF
--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -46,6 +46,22 @@ namespace pl::core {
             return this->m_result;
         }
 
+        [[nodiscard]] auto getOutput() const {
+            return this->m_output;
+        }
+
+        void setOutput(std::vector<pl::core::Token> tokens) {
+            m_output = tokens;
+        }
+
+        [[nodiscard]] auto getErrors() const {
+            return this->m_errors;
+        }
+
+        void setErrors(std::vector<err::CompileError> errors) {
+            m_errors = errors;
+        }
+
         [[nodiscard]] bool shouldOnlyIncludeOnce() const {
             return this->m_onlyIncludeOnce;
         }
@@ -57,6 +73,12 @@ namespace pl::core {
         void setResolver(const api::Resolver& resolvers) {
             m_resolver = resolvers;
         }
+
+        auto getNamespaces() const {
+            return m_namespaces;
+        }
+
+        void appendToNamespaces(std::vector<Token> namespaces);
 
     private:
         Preprocessor(const Preprocessor &);
@@ -95,6 +117,7 @@ namespace pl::core {
         std::vector<err::CompileError> m_errors;
         std::vector<Token> m_result;
         std::vector<Token> m_output;
+        std::vector<std::string> m_namespaces;
 
         api::Source* m_source = nullptr;
 

--- a/lib/include/pl/core/token.hpp
+++ b/lib/include/pl/core/token.hpp
@@ -172,10 +172,12 @@ namespace pl::core {
                 Unknown,
                 FunctionUnknown,
                 MemberUnknown,
+                ScopeResolutionUnknown,
                 UDT,
                 PatternVariable,
                 PatternLocalVariable,
                 PatternPlacedVariable,
+                TemplateArgument,
                 FunctionVariable,
                 FunctionParameter,
                 PlacedVariable,
@@ -194,7 +196,7 @@ namespace pl::core {
 
             [[nodiscard]] const std::string &get() const { return this->m_identifier; }
             [[nodiscard]] IdentifierType getType() const { return this->m_type; }
-            void setType(IdentifierType idtype) { this->m_type = idtype; }
+            void setType(IdentifierType idtype, bool force = false);
 
 
             bool operator==(const Identifier &) const  = default;

--- a/lib/include/pl/core/tokens.hpp
+++ b/lib/include/pl/core/tokens.hpp
@@ -83,6 +83,8 @@ namespace pl::core::tkn {
         const auto Identifier = makeToken(core::Token::Type::Identifier, { });
         const auto Numeric    = makeToken(core::Token::Type::Integer, { });
         const auto String     = makeToken(core::Token::Type::String,  { });
+        const auto DocComment = makeToken(core::Token::Type::DocComment, { });
+        const auto Comment    = makeToken(core::Token::Type::Comment, { });
 
     }
 

--- a/lib/include/pl/pattern_language.hpp
+++ b/lib/include/pl/pattern_language.hpp
@@ -328,6 +328,10 @@ namespace pl {
             return this->m_defines;
         }
 
+        [[nodiscard]] const std::vector<std::shared_ptr<core::ast::ASTNode>> getAST() const {
+            return this->m_currAST;
+        }
+
         [[nodiscard]] const std::map<std::string, api::PragmaHandler>& getPragmas() const {
             return this->m_pragmas;
         }

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -124,7 +124,7 @@ namespace pl::core {
         m_cursor++; // Skip space
         auto location = this->location();
 
-        while (!std::isblank(m_sourceCode[m_cursor]) && !std::isspace(m_sourceCode[m_cursor]) ) {
+        while (!std::isblank(m_sourceCode[m_cursor]) && !std::isspace(m_sourceCode[m_cursor]) && m_sourceCode[m_cursor] != '\0' ) {
 
             auto character = parseCharacter();
             if (!character.has_value()) {

--- a/lib/source/pl/core/parser_manager.cpp
+++ b/lib/source/pl/core/parser_manager.cpp
@@ -27,6 +27,7 @@ pl::hlp::CompileResult<ParserManager::ParsedData> ParserManager::parse(api::Sour
     }
 
     const auto& internals = m_patternLanguage->getInternals();
+    auto oldPreprpocessor = internals.preprocessor.get();
 
     auto preprocessor = Preprocessor();
     for (const auto& [name, value] : m_patternLanguage->getDefines()) {
@@ -51,6 +52,7 @@ pl::hlp::CompileResult<ParserManager::ParsedData> ParserManager::parse(api::Sour
     parser.m_aliasNamespaceString = namespacePrefix;
 
     auto result = parser.parse(tokens.value());
+    oldPreprpocessor->appendToNamespaces(tokens.value());
     if (result.hasErrs())
         return result_t::err(result.errs);
 

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -393,6 +393,12 @@ namespace pl::core {
         return false;
     }
 
+    void Token::Identifier::setType(Identifier::IdentifierType idtype, bool force) {
+        if (force || this->m_type == Identifier::IdentifierType::Unknown || this->m_type == Identifier::IdentifierType::MemberUnknown
+            || this->m_type == Identifier::IdentifierType::FunctionUnknown || this->m_type == Identifier::IdentifierType::ScopeResolutionUnknown)
+            this->m_type = idtype;
+    }
+	
     bool Token::operator!=(const ValueTypes &other) const {
         return !operator==(other);
     }

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -98,20 +98,24 @@ namespace pl {
 
         if (!ast.has_value() || ast->empty())
             return std::nullopt;
+        this->m_internals.preprocessor->setOutput(tokens.value());
 
         auto [validated, validatorErrors] = this->m_internals.validator->validate(ast.value());
         wolv::util::unused(validated);
         if (!validatorErrors.empty())
             this->m_compileErrors = std::move(validatorErrors);
 
+
+        this->m_internals.preprocessor->setErrors(this->m_compileErrors);
+
         if (ast->empty() || !ast.has_value())
             return std::nullopt;
-
-        return ast;
+        this->m_currAST = std::move(*ast);
+        return m_currAST;
     }
 
     bool PatternLanguage::executeString(std::string code, const std::string& source, const std::map<std::string, core::Token::Literal> &envVars, const std::map<std::string, core::Token::Literal> &inVariables, bool checkResult) {
-        const auto startTime = std::chrono::high_resolution_clock::now();
+	   	const auto startTime = std::chrono::high_resolution_clock::now();
         ON_SCOPE_EXIT {
             const auto endTime = std::chrono::high_resolution_clock::now();
             this->m_runningTime = std::chrono::duration_cast<std::chrono::duration<double>>(endTime - startTime).count();


### PR DESCRIPTION
Other fixes/changes include:

Fix: lexer was reading include folders past the end of file when include was the last token in file.
Highlighter: parser.cpp now provides better information about the identifier types.
Highlighter: Some information couldn't be obtained because the parser created new preprocessors and new token streams to parse imported files which were later destroyed when no longer in use. In particular the namespaces encountered during parsing were only stored in the ASTs as parts of the names of functions and custom types. I resolve this by letting the preprocessor store the namespaces and saving them to a vector. Because new preprocessors were being created (and destroyed) I also open the original preprocessor used before the parser to copy the information from the new preprocessors so that it can be accessed when highlighting.
Highlighter: I took some basic timing measurements and the slowest part by far far was the lexing-preprocessing-parsing, that is, the creation of the token stream and the ASTNode vector. Currently, when any change in the text editor occurs a background task is created to parse the code. This is needed to deal with in and out variables, but I thought that instead of  redoing it all over again I could just use the results obtained in the task. Unfortunately the AST is not saved and it is thrown away, so I change the code to make sure that m_currAST gets loaded with that result.
  Highlighter: template variables were missing in the list of identifier types so it was added as well.