### PR TITLE
fix: pointers in structures placed in a section

### DIFF
--- a/lib/source/pl/core/ast/ast_node_pointer_variable_decl.cpp
+++ b/lib/source/pl/core/ast/ast_node_pointer_variable_decl.cpp
@@ -64,6 +64,7 @@ namespace pl::core::ast {
             err::E0005.throwError("'auto' can only be used with parameters.", { }, this->getLocation());
 
         auto &sizePattern = sizePatterns.front();
+        sizePattern->setSection(evaluator->getSectionId());
 
         auto pattern = std::make_shared<ptrn::PatternPointer>(evaluator, pointerStartOffset, sizePattern->getSize(), getLocation().line);
         pattern->setVariableName(this->m_name);


### PR DESCRIPTION
Having a pointer in structure, that is placed in a section results in pointer value being read from main file, instead of the section.
![image](https://github.com/WerWolv/PatternLanguage/assets/27638710/b1942de8-3709-4ebe-a25b-ded4aa182126)

