### PR TITLE
Fix: hexadecimal literals can create invalid tokens.

### DIFF
--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -46,7 +46,7 @@ namespace pl::core {
     static size_t getIntegerLiteralLength(const std::string_view& literal) {
         const auto count = literal.find_first_not_of("0123456789ABCDEFabcdef'xXoOpP.uU+-");
         const std::string_view intLiteral = count == std::string_view::npos ? literal : literal.substr(0, count);
-        if (const auto signPos = intLiteral.find_first_of("+-"); signPos != std::string_view::npos && literal.at(signPos-1) != 'e' && literal.at(signPos-1) != 'E')
+        if (const auto signPos = intLiteral.find_first_of("+-"); signPos != std::string_view::npos && ((literal.at(signPos-1) != 'e' && literal.at(signPos-1) != 'E')  || literal.starts_with("0x")))
             return signPos;
         return intLiteral.size();
     }


### PR DESCRIPTION
Numeric literals of hexadecimals that ended in `E` or `e` failed to produce valid tokens if it was followed by `+` or `-` with no space in between. The fix is to check if literal starts with `0x` in which case the `+` or `-` is not included in the token for the numeric literal.