### PR TITLE
fix: Do not use fmt::println() because it is not available everywhere yet

### DIFF
--- a/cli/source/helpers/utils.cpp
+++ b/cli/source/helpers/utils.cpp
@@ -36,9 +36,9 @@ namespace pl::cli {
         if (!runtime.executeString(patternFile.readString(), wolv::util::toUTF8String(patternFile.getPath()))) {
             auto compileErrors = runtime.getCompileErrors();
             if (compileErrors.size()>0) {
-                fmt::println("Compilation failed");
+                fmt::print("Compilation failed\n");
                 for (const auto &error : compileErrors) {
-                    fmt::println("{}", error.format());
+                    fmt::print("{}\n", error.format());
                 }
             } else {
                 auto error = runtime.getError().value();

--- a/cli/source/subcommands/docs.cpp
+++ b/cli/source/subcommands/docs.cpp
@@ -150,9 +150,9 @@ namespace pl::cli::sub {
             if (!ast.has_value()) {
                 auto compileErrors = runtime.getCompileErrors();
                 if (compileErrors.size()>0) {
-                    fmt::println("Compilation failed");
+                    fmt::print("Compilation failed\n");
                     for (const auto &error : compileErrors) {
-                        fmt::println("{}", error.format());
+                        fmt::print("{}\n", error.format());
                     }
                 } else {
                     auto error = runtime.getError().value();

--- a/cli/source/subcommands/info.cpp
+++ b/cli/source/subcommands/info.cpp
@@ -100,9 +100,9 @@ namespace pl::cli::sub {
             if (!ast.has_value()) {
                 auto compileErrors = runtime.getCompileErrors();
                 if (compileErrors.size()>0) {
-                    fmt::println("Compilation failed");
+                    fmt::print("Compilation failed\n");
                     for (const auto &error : compileErrors) {
-                        fmt::println("{}", error.format());
+                        fmt::print("{}\n", error.format());
                     }
                 } else {
                     auto error = runtime.getError().value();

--- a/cli/source/subcommands/run.cpp
+++ b/cli/source/subcommands/run.cpp
@@ -79,9 +79,9 @@ namespace pl::cli::sub {
             if (!runtime.executeFile(patternFilePath)) {
                 auto compileErrors = runtime.getCompileErrors();
                 if (compileErrors.size()>0) {
-                    fmt::println("Compilation failed");
+                    fmt::print("Compilation failed\n");
                     for (const auto &error : compileErrors) {
-                        fmt::println("{}", error.format());
+                        fmt::print("{}\n", error.format());
                     }
                 } else {
                     auto error = runtime.getError().value();


### PR DESCRIPTION
This fix a problem I introduced in https://github.com/WerWolv/PatternLanguage/pull/97

fmt::println() is not available on all Linux distros yet, so this makes the ImHex build fail