### PR TITLE
refactor/fix: fix Pattern::callUserFormatFunc() (previously Pattern::formatDisplayValue() with 3 args)  sharing cache with Pattern::getFormattedValue()

### DIFF
--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -540,9 +540,6 @@ namespace pl::ptrn {
                                 string = result->toString(true);
                             }
 
-
-                            this->m_cachedDisplayValue = std::make_unique<std::string>(string);
-
                             return string;
                         } else {
                             return "";

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -518,9 +518,6 @@ namespace pl::ptrn {
         [[nodiscard]] virtual std::string formatDisplayValue() = 0;
 
         [[nodiscard]] std::string formatDisplayValue(const std::string &defaultValue, const core::Token::Literal &literal, bool fromCast = false) const {
-            if (this->m_cachedDisplayValue != nullptr)
-                return *this->m_cachedDisplayValue;
-
             const auto &formatterFunctionName = this->getReadFormatterFunction();
             if (formatterFunctionName.empty())
                 return defaultValue;

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -517,13 +517,13 @@ namespace pl::ptrn {
 
         [[nodiscard]] virtual std::string formatDisplayValue() = 0;
 
-        [[nodiscard]] std::string formatDisplayValue(const std::string &value, const core::Token::Literal &literal, bool fromCast = false) const {
+        [[nodiscard]] std::string formatDisplayValue(const std::string &defaultValue, const core::Token::Literal &literal, bool fromCast = false) const {
             if (this->m_cachedDisplayValue != nullptr)
                 return *this->m_cachedDisplayValue;
 
             const auto &formatterFunctionName = this->getReadFormatterFunction();
             if (formatterFunctionName.empty())
-                return value;
+                return defaultValue;
             else {
                 try {
                     const auto function = this->m_evaluator->findFunction(formatterFunctionName);
@@ -535,7 +535,7 @@ namespace pl::ptrn {
                         if (result.has_value()) {
                             std::string string;
                             if (fromCast && result->isPattern() && result->toPattern()->getTypeName() == this->getTypeName()) {
-                                string = value;
+                                string = defaultValue;
                             } else {
                                 string = result->toString(true);
                             }

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -533,20 +533,14 @@ namespace pl::ptrn {
 
                         auto result = function->func(this->m_evaluator, { literal });
                         if (result.has_value()) {
-                            std::string string;
                             if (fromCast && result->isPattern() && result->toPattern()->getTypeName() == this->getTypeName()) {
                                 return {};
                             } else {
                                 return result->toString(true);
                             }
-
-                            return {};
-                        } else {
-                            return {};
                         }
-                    } else {
-                        return {};
                     }
+                    return {};
 
                 } catch (core::err::EvaluatorError::Exception &error) {
                     return error.what();

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -516,7 +516,10 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] virtual std::string formatDisplayValue() = 0;
-
+        
+        /**
+         * @brief Calls an user-defined PL function to format the given literal (pattern), if existing. Else, returns defaultValue
+        */
         [[nodiscard]] std::string callUserFormatFunc(const std::string &defaultValue, const core::Token::Literal &literal, bool fromCast = false) const {
             const auto &formatterFunctionName = this->getReadFormatterFunction();
             if (formatterFunctionName.empty())

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -238,7 +238,7 @@ namespace pl::ptrn {
         [[nodiscard]] virtual std::string toString() const {
             auto result = fmt::format("{} {} @ 0x{:X}", this->getTypeName(), this->getVariableName(), this->getOffset());
 
-            return this->formatDisplayValue(result, this->getValue(), true);
+            return this->callUserFormatFunc(result, this->getValue(), true);
         }
 
         [[nodiscard]] virtual core::Token::Literal getValue() const {
@@ -517,7 +517,7 @@ namespace pl::ptrn {
 
         [[nodiscard]] virtual std::string formatDisplayValue() = 0;
 
-        [[nodiscard]] std::string formatDisplayValue(const std::string &defaultValue, const core::Token::Literal &literal, bool fromCast = false) const {
+        [[nodiscard]] std::string callUserFormatFunc(const std::string &defaultValue, const core::Token::Literal &literal, bool fromCast = false) const {
             const auto &formatterFunctionName = this->getReadFormatterFunction();
             if (formatterFunctionName.empty())
                 return defaultValue;

--- a/lib/include/pl/patterns/pattern_array_dynamic.hpp
+++ b/lib/include/pl/patterns/pattern_array_dynamic.hpp
@@ -165,7 +165,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::formatDisplayValue(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(result, this->clone(), true);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override {
@@ -200,7 +200,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::formatDisplayValue("[ ... ]", this->clone());
+            return Pattern::callUserFormatFunc("[ ... ]", this->clone());
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_array_dynamic.hpp
+++ b/lib/include/pl/patterns/pattern_array_dynamic.hpp
@@ -165,7 +165,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::callUserFormatFunc(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(this->clone(), true).value_or(result);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override {
@@ -200,7 +200,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc("[ ... ]", this->clone());
+            return Pattern::callUserFormatFunc(this->clone()).value_or("[ ... ]");
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_array_static.hpp
+++ b/lib/include/pl/patterns/pattern_array_static.hpp
@@ -193,7 +193,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::formatDisplayValue("[ ... ]", this->clone());
+            return Pattern::callUserFormatFunc("[ ... ]", this->clone());
         }
 
         [[nodiscard]] std::string toString() const override {
@@ -222,7 +222,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::formatDisplayValue(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(result, this->clone(), true);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_array_static.hpp
+++ b/lib/include/pl/patterns/pattern_array_static.hpp
@@ -193,7 +193,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc("[ ... ]", this->clone());
+            return Pattern::callUserFormatFunc(this->clone()).value_or("[ ... ]");
         }
 
         [[nodiscard]] std::string toString() const override {
@@ -222,7 +222,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::callUserFormatFunc(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(this->clone(), true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -112,12 +112,12 @@ namespace pl::ptrn {
         std::string formatDisplayValue() override {
             auto literal = this->getValue();
             auto value = literal.toUnsigned();
-            return Pattern::formatDisplayValue(fmt::format("{} (0x{:X})", value, value), literal);
+            return Pattern::callUserFormatFunc(fmt::format("{} (0x{:X})", value, value), literal);
         }
 
         [[nodiscard]] std::string toString() const override {
             auto value = this->readValue();
-            return Pattern::formatDisplayValue(fmt::format("{}", value), value, true);
+            return Pattern::callUserFormatFunc(fmt::format("{}", value), value, true);
         }
 
         [[nodiscard]] bool isPadding() const override { return this->m_padding; }
@@ -179,12 +179,12 @@ namespace pl::ptrn {
         std::string formatDisplayValue() override {
             auto rawValue = this->readValue();
             auto value = hlp::signExtend(this->getBitSize(), rawValue);
-            return Pattern::formatDisplayValue(fmt::format("{} (0x{:X})", value, rawValue), value);
+            return Pattern::callUserFormatFunc(fmt::format("{} (0x{:X})", value, rawValue), value);
         }
 
         [[nodiscard]] std::string toString() const override {
             auto result = fmt::format("{}", this->getValue().toSigned());
-            return Pattern::formatDisplayValue(result, this->getValue(), true);
+            return Pattern::callUserFormatFunc(result, this->getValue(), true);
         }
     };
 
@@ -214,7 +214,7 @@ namespace pl::ptrn {
 
         [[nodiscard]] std::string toString() const override {
             auto value = this->getValue();
-            return Pattern::formatDisplayValue(fmt::format("{}", value.toBoolean() ? "true" : "false"), value, true);
+            return Pattern::callUserFormatFunc(fmt::format("{}", value.toBoolean() ? "true" : "false"), value, true);
         }
     };
 
@@ -253,12 +253,12 @@ namespace pl::ptrn {
         std::string formatDisplayValue() override {
             auto value = this->readValue();
             auto enumName = PatternEnum::getEnumName(this->getTypeName(), value, this->getEnumValues());
-            return Pattern::formatDisplayValue(fmt::format("{} (0x{:X})", enumName, value), value);
+            return Pattern::callUserFormatFunc(fmt::format("{} (0x{:X})", enumName, value), value);
         }
 
         [[nodiscard]] std::string toString() const override {
             auto enumName = PatternEnum::getEnumName(this->getTypeName(), this->readValue(), this->getEnumValues());
-            return Pattern::formatDisplayValue(enumName, this->getValue(), true);
+            return Pattern::callUserFormatFunc(enumName, this->getValue(), true);
         }
 
     private:
@@ -465,7 +465,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::formatDisplayValue(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(result, this->clone(), true);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override {
@@ -505,7 +505,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return PatternBitfieldMember::formatDisplayValue("[ ... ]", this->clone());
+            return Pattern::callUserFormatFunc("[ ... ]", this->clone());
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -709,7 +709,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::formatDisplayValue(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(result, this->clone(), true);
         }
 
         std::string formatDisplayValue() override {
@@ -744,7 +744,7 @@ namespace pl::ptrn {
                 valueString.pop_back();
             }
 
-            return Pattern::formatDisplayValue(fmt::format("{{ {} }}", valueString), this->clone());
+            return Pattern::callUserFormatFunc(fmt::format("{{ {} }}", valueString), this->clone());
         }
 
         void setEndian(std::endian endian) override {

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -112,12 +112,12 @@ namespace pl::ptrn {
         std::string formatDisplayValue() override {
             auto literal = this->getValue();
             auto value = literal.toUnsigned();
-            return Pattern::callUserFormatFunc(fmt::format("{} (0x{:X})", value, value), literal);
+            return Pattern::callUserFormatFunc(literal).value_or(fmt::format("{} (0x{:X})", value, value));
         }
 
         [[nodiscard]] std::string toString() const override {
             auto value = this->readValue();
-            return Pattern::callUserFormatFunc(fmt::format("{}", value), value, true);
+            return Pattern::callUserFormatFunc(value, true).value_or(fmt::format("{}", value));
         }
 
         [[nodiscard]] bool isPadding() const override { return this->m_padding; }
@@ -179,12 +179,12 @@ namespace pl::ptrn {
         std::string formatDisplayValue() override {
             auto rawValue = this->readValue();
             auto value = hlp::signExtend(this->getBitSize(), rawValue);
-            return Pattern::callUserFormatFunc(fmt::format("{} (0x{:X})", value, rawValue), value);
+            return Pattern::callUserFormatFunc(value).value_or(fmt::format("{} (0x{:X})", value, rawValue));
         }
 
         [[nodiscard]] std::string toString() const override {
             auto result = fmt::format("{}", this->getValue().toSigned());
-            return Pattern::callUserFormatFunc(result, this->getValue(), true);
+            return Pattern::callUserFormatFunc(this->getValue(), true).value_or(result);
         }
     };
 
@@ -214,7 +214,7 @@ namespace pl::ptrn {
 
         [[nodiscard]] std::string toString() const override {
             auto value = this->getValue();
-            return Pattern::callUserFormatFunc(fmt::format("{}", value.toBoolean() ? "true" : "false"), value, true);
+            return Pattern::callUserFormatFunc(value, true).value_or(fmt::format("{}", value.toBoolean() ? "true" : "false"));
         }
     };
 
@@ -253,12 +253,12 @@ namespace pl::ptrn {
         std::string formatDisplayValue() override {
             auto value = this->readValue();
             auto enumName = PatternEnum::getEnumName(this->getTypeName(), value, this->getEnumValues());
-            return Pattern::callUserFormatFunc(fmt::format("{} (0x{:X})", enumName, value), value);
+            return Pattern::callUserFormatFunc(value).value_or(fmt::format("{} (0x{:X})", enumName, value));
         }
 
         [[nodiscard]] std::string toString() const override {
             auto enumName = PatternEnum::getEnumName(this->getTypeName(), this->readValue(), this->getEnumValues());
-            return Pattern::callUserFormatFunc(enumName, this->getValue(), true);
+            return Pattern::callUserFormatFunc(this->getValue(), true).value_or(enumName);
         }
 
     private:
@@ -465,7 +465,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::callUserFormatFunc(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(this->clone(), true).value_or(result);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override {
@@ -505,7 +505,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc("[ ... ]", this->clone());
+            return Pattern::callUserFormatFunc(this->clone()).value_or("[ ... ]");
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -709,7 +709,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::callUserFormatFunc(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(this->clone(), true).value_or(result);
         }
 
         std::string formatDisplayValue() override {
@@ -744,7 +744,7 @@ namespace pl::ptrn {
                 valueString.pop_back();
             }
 
-            return Pattern::callUserFormatFunc(fmt::format("{{ {} }}", valueString), this->clone());
+            return Pattern::callUserFormatFunc(this->clone()).value_or(fmt::format("{{ {} }}", valueString));
         }
 
         void setEndian(std::endian endian) override {

--- a/lib/include/pl/patterns/pattern_boolean.hpp
+++ b/lib/include/pl/patterns/pattern_boolean.hpp
@@ -49,7 +49,7 @@ namespace pl::ptrn {
             auto value = this->getValue();
             auto result = fmt::format("{}", value.toBoolean() ? "true" : "false");
 
-            return Pattern::callUserFormatFunc(result, value, true);
+            return Pattern::callUserFormatFunc(value, true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_boolean.hpp
+++ b/lib/include/pl/patterns/pattern_boolean.hpp
@@ -49,7 +49,7 @@ namespace pl::ptrn {
             auto value = this->getValue();
             auto result = fmt::format("{}", value.toBoolean() ? "true" : "false");
 
-            return Pattern::formatDisplayValue(result, value, true);
+            return Pattern::callUserFormatFunc(result, value, true);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_character.hpp
+++ b/lib/include/pl/patterns/pattern_character.hpp
@@ -33,7 +33,7 @@ namespace pl::ptrn {
 
         std::string formatDisplayValue() override {
             const u8 character = this->getValue().toCharacter();
-            return Pattern::callUserFormatFunc(fmt::format("'{0}'", hlp::encodeByteString({ character })), this->getValue());
+            return Pattern::callUserFormatFunc(this->getValue()).value_or(fmt::format("'{0}'", hlp::encodeByteString({ character })));
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override { return compareCommonProperties<decltype(*this)>(other); }
@@ -46,7 +46,7 @@ namespace pl::ptrn {
             auto value = this->getValue();
             auto result = fmt::format("{}", hlp::encodeByteString({ u8(value.toCharacter()) }));
 
-            return Pattern::callUserFormatFunc(result, value, true);
+            return Pattern::callUserFormatFunc(value, true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_character.hpp
+++ b/lib/include/pl/patterns/pattern_character.hpp
@@ -33,7 +33,7 @@ namespace pl::ptrn {
 
         std::string formatDisplayValue() override {
             const u8 character = this->getValue().toCharacter();
-            return Pattern::formatDisplayValue(fmt::format("'{0}'", hlp::encodeByteString({ character })), this->getValue());
+            return Pattern::callUserFormatFunc(fmt::format("'{0}'", hlp::encodeByteString({ character })), this->getValue());
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override { return compareCommonProperties<decltype(*this)>(other); }
@@ -46,7 +46,7 @@ namespace pl::ptrn {
             auto value = this->getValue();
             auto result = fmt::format("{}", hlp::encodeByteString({ u8(value.toCharacter()) }));
 
-            return Pattern::formatDisplayValue(result, value, true);
+            return Pattern::callUserFormatFunc(result, value, true);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_enum.hpp
+++ b/lib/include/pl/patterns/pattern_enum.hpp
@@ -90,7 +90,7 @@ namespace pl::ptrn {
 
         [[nodiscard]] std::string toString() const override {
             u128 value = this->getValue().toUnsigned();
-            return Pattern::formatDisplayValue(getEnumName(this->getTypeName(), value, this->m_enumValues), this->clone(), true);
+            return Pattern::callUserFormatFunc(getEnumName(this->getTypeName(), value, this->m_enumValues), this->clone(), true);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_enum.hpp
+++ b/lib/include/pl/patterns/pattern_enum.hpp
@@ -90,7 +90,7 @@ namespace pl::ptrn {
 
         [[nodiscard]] std::string toString() const override {
             u128 value = this->getValue().toUnsigned();
-            return Pattern::callUserFormatFunc(getEnumName(this->getTypeName(), value, this->m_enumValues), this->clone(), true);
+            return Pattern::callUserFormatFunc(this->clone(), true).value_or(getEnumName(this->getTypeName(), value, this->m_enumValues));
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_float.hpp
+++ b/lib/include/pl/patterns/pattern_float.hpp
@@ -70,12 +70,12 @@ namespace pl::ptrn {
                 auto f32 = static_cast<float>(value);
                 u32 integerResult = 0;
                 std::memcpy(&integerResult, &f32, sizeof(float));
-                return Pattern::callUserFormatFunc(fmt::format("{:g} (0x{:0{}X})", f32, integerResult, this->getSize() * 2), f32);
+                return Pattern::callUserFormatFunc(f32).value_or(fmt::format("{:g} (0x{:0{}X})", f32, integerResult, this->getSize() * 2));
             } else if (this->getSize() == 8) {
                 auto f64 = static_cast<double>(value);
                 u64 integerResult = 0;
                 std::memcpy(&integerResult, &f64, sizeof(double));
-                return Pattern::callUserFormatFunc(fmt::format("{:g} (0x{:0{}X})", f64, integerResult, this->getSize() * 2), f64);
+                return Pattern::callUserFormatFunc(f64).value_or(fmt::format("{:g} (0x{:0{}X})", f64, integerResult, this->getSize() * 2));
             } else {
                 return "Floating Point Data";
             }
@@ -85,7 +85,7 @@ namespace pl::ptrn {
             auto value = this->getValue();
             auto result = fmt::format("{}", value.toFloatingPoint());
 
-            return Pattern::callUserFormatFunc(result, value, true);
+            return Pattern::callUserFormatFunc(value, true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_float.hpp
+++ b/lib/include/pl/patterns/pattern_float.hpp
@@ -70,12 +70,12 @@ namespace pl::ptrn {
                 auto f32 = static_cast<float>(value);
                 u32 integerResult = 0;
                 std::memcpy(&integerResult, &f32, sizeof(float));
-                return Pattern::formatDisplayValue(fmt::format("{:g} (0x{:0{}X})", f32, integerResult, this->getSize() * 2), f32);
+                return Pattern::callUserFormatFunc(fmt::format("{:g} (0x{:0{}X})", f32, integerResult, this->getSize() * 2), f32);
             } else if (this->getSize() == 8) {
                 auto f64 = static_cast<double>(value);
                 u64 integerResult = 0;
                 std::memcpy(&integerResult, &f64, sizeof(double));
-                return Pattern::formatDisplayValue(fmt::format("{:g} (0x{:0{}X})", f64, integerResult, this->getSize() * 2), f64);
+                return Pattern::callUserFormatFunc(fmt::format("{:g} (0x{:0{}X})", f64, integerResult, this->getSize() * 2), f64);
             } else {
                 return "Floating Point Data";
             }
@@ -85,7 +85,7 @@ namespace pl::ptrn {
             auto value = this->getValue();
             auto result = fmt::format("{}", value.toFloatingPoint());
 
-            return Pattern::formatDisplayValue(result, value, true);
+            return Pattern::callUserFormatFunc(result, value, true);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_padding.hpp
+++ b/lib/include/pl/patterns/pattern_padding.hpp
@@ -38,7 +38,7 @@ namespace pl::ptrn {
                    return fmt::format("padding[{}]", this->getSize());
             }();
 
-            return Pattern::formatDisplayValue(result, this->getValue(), true);
+            return Pattern::callUserFormatFunc(result, this->getValue(), true);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_padding.hpp
+++ b/lib/include/pl/patterns/pattern_padding.hpp
@@ -38,7 +38,7 @@ namespace pl::ptrn {
                    return fmt::format("padding[{}]", this->getSize());
             }();
 
-            return Pattern::callUserFormatFunc(result, this->getValue(), true);
+            return Pattern::callUserFormatFunc(this->getValue(), true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_pointer.hpp
+++ b/lib/include/pl/patterns/pattern_pointer.hpp
@@ -149,13 +149,13 @@ namespace pl::ptrn {
 
         std::string formatDisplayValue() override {
             auto data = this->getValue().toSigned();
-            return Pattern::callUserFormatFunc(fmt::format("*(0x{0:X})", data), this->getValue());
+            return Pattern::callUserFormatFunc(this->getValue()).value_or(fmt::format("*(0x{0:X})", data));
         }
 
         [[nodiscard]] std::string toString() const override {
             auto result = this->m_pointedAt->toString();
 
-            return Pattern::callUserFormatFunc(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(this->clone(), true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_pointer.hpp
+++ b/lib/include/pl/patterns/pattern_pointer.hpp
@@ -149,13 +149,13 @@ namespace pl::ptrn {
 
         std::string formatDisplayValue() override {
             auto data = this->getValue().toSigned();
-            return Pattern::formatDisplayValue(fmt::format("*(0x{0:X})", data), this->getValue());
+            return Pattern::callUserFormatFunc(fmt::format("*(0x{0:X})", data), this->getValue());
         }
 
         [[nodiscard]] std::string toString() const override {
             auto result = this->m_pointedAt->toString();
 
-            return Pattern::formatDisplayValue(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(result, this->clone(), true);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_signed.hpp
+++ b/lib/include/pl/patterns/pattern_signed.hpp
@@ -35,14 +35,14 @@ namespace pl::ptrn {
             auto data = this->getValue().toSigned();
             auto size = this->getSize();
 
-            return Pattern::callUserFormatFunc(fmt::format("{:d} (0x{:0{}X})", data, u128(data) & hlp::bitmask(8 * size), size * 2), this->getValue());
+            return Pattern::callUserFormatFunc(this->getValue()).value_or(fmt::format("{:d} (0x{:0{}X})", data, u128(data) & hlp::bitmask(8 * size), size * 2));
         }
 
         [[nodiscard]] std::string toString() const override {
             auto value = this->getValue();
             auto result = fmt::format("{:d}", value.toSigned());
 
-            return Pattern::callUserFormatFunc(result, value, true);
+            return Pattern::callUserFormatFunc(value, true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_signed.hpp
+++ b/lib/include/pl/patterns/pattern_signed.hpp
@@ -35,14 +35,14 @@ namespace pl::ptrn {
             auto data = this->getValue().toSigned();
             auto size = this->getSize();
 
-            return Pattern::formatDisplayValue(fmt::format("{:d} (0x{:0{}X})", data, u128(data) & hlp::bitmask(8 * size), size * 2), this->getValue());
+            return Pattern::callUserFormatFunc(fmt::format("{:d} (0x{:0{}X})", data, u128(data) & hlp::bitmask(8 * size), size * 2), this->getValue());
         }
 
         [[nodiscard]] std::string toString() const override {
             auto value = this->getValue();
             auto result = fmt::format("{:d}", value.toSigned());
 
-            return Pattern::formatDisplayValue(result, value, true);
+            return Pattern::callUserFormatFunc(result, value, true);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_string.hpp
+++ b/lib/include/pl/patterns/pattern_string.hpp
@@ -53,7 +53,7 @@ namespace pl::ptrn {
             auto value = this->getValue();
             auto result = value.toString(false);
 
-            return Pattern::formatDisplayValue(result, value, true);
+            return Pattern::callUserFormatFunc(result, value, true);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override { return compareCommonProperties<decltype(*this)>(other); }
@@ -72,7 +72,7 @@ namespace pl::ptrn {
             this->getEvaluator()->readData(this->getOffset(), buffer.data(), size, this->getSection());
             auto displayString = hlp::encodeByteString({ buffer.begin(), buffer.end() });
 
-            return Pattern::formatDisplayValue(fmt::format("\"{0}\" {1}", displayString, size > this->getSize() ? "(truncated)" : ""), buffer);
+            return Pattern::callUserFormatFunc(fmt::format("\"{0}\" {1}", displayString, size > this->getSize() ? "(truncated)" : ""), buffer);
         }
 
         std::shared_ptr<Pattern> getEntry(size_t index) const override {

--- a/lib/include/pl/patterns/pattern_string.hpp
+++ b/lib/include/pl/patterns/pattern_string.hpp
@@ -53,7 +53,7 @@ namespace pl::ptrn {
             auto value = this->getValue();
             auto result = value.toString(false);
 
-            return Pattern::callUserFormatFunc(result, value, true);
+            return Pattern::callUserFormatFunc(value, true).value_or(result);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override { return compareCommonProperties<decltype(*this)>(other); }
@@ -72,7 +72,7 @@ namespace pl::ptrn {
             this->getEvaluator()->readData(this->getOffset(), buffer.data(), size, this->getSection());
             auto displayString = hlp::encodeByteString({ buffer.begin(), buffer.end() });
 
-            return Pattern::callUserFormatFunc(fmt::format("\"{0}\" {1}", displayString, size > this->getSize() ? "(truncated)" : ""), buffer);
+            return Pattern::callUserFormatFunc(buffer).value_or(fmt::format("\"{0}\" {1}", displayString, size > this->getSize() ? "(truncated)" : ""));
         }
 
         std::shared_ptr<Pattern> getEntry(size_t index) const override {

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -143,7 +143,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::callUserFormatFunc(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(this->clone(), true).value_or(result);
         }
 
         void setMembers(std::vector<std::shared_ptr<Pattern>> members) {
@@ -203,7 +203,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc("{ ... }", this->clone());
+            return Pattern::callUserFormatFunc(this->clone()).value_or("{ ... }");
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -143,7 +143,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::formatDisplayValue(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(result, this->clone(), true);
         }
 
         void setMembers(std::vector<std::shared_ptr<Pattern>> members) {
@@ -203,7 +203,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::formatDisplayValue("{ ... }", this->clone());
+            return Pattern::callUserFormatFunc("{ ... }", this->clone());
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_union.hpp
+++ b/lib/include/pl/patterns/pattern_union.hpp
@@ -156,7 +156,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::callUserFormatFunc(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(this->clone(), true).value_or(result);
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -202,7 +202,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc("{ ... }", this->clone());
+            return Pattern::callUserFormatFunc(this->clone()).value_or("{ ... }");
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_union.hpp
+++ b/lib/include/pl/patterns/pattern_union.hpp
@@ -156,7 +156,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::formatDisplayValue(result, this->clone(), true);
+            return Pattern::callUserFormatFunc(result, this->clone(), true);
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -202,7 +202,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::formatDisplayValue("{ ... }", this->clone());
+            return Pattern::callUserFormatFunc("{ ... }", this->clone());
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_unsigned.hpp
+++ b/lib/include/pl/patterns/pattern_unsigned.hpp
@@ -31,14 +31,14 @@ namespace pl::ptrn {
 
         std::string formatDisplayValue() override {
             auto data = this->getValue().toUnsigned();
-            return Pattern::formatDisplayValue(fmt::format("{:d} (0x{:0{}X})", data, data, this->getSize() * 2), this->getValue());
+            return Pattern::callUserFormatFunc(fmt::format("{:d} (0x{:0{}X})", data, data, this->getSize() * 2), this->getValue());
         }
 
         [[nodiscard]] std::string toString() const override {
             auto value = this->getValue();
             auto result = fmt::format("{:d}", value.toUnsigned());
 
-            return Pattern::formatDisplayValue(result, value, true);
+            return Pattern::callUserFormatFunc(result, value, true);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_unsigned.hpp
+++ b/lib/include/pl/patterns/pattern_unsigned.hpp
@@ -31,14 +31,14 @@ namespace pl::ptrn {
 
         std::string formatDisplayValue() override {
             auto data = this->getValue().toUnsigned();
-            return Pattern::callUserFormatFunc(fmt::format("{:d} (0x{:0{}X})", data, data, this->getSize() * 2), this->getValue());
+            return Pattern::callUserFormatFunc(this->getValue()).value_or(fmt::format("{:d} (0x{:0{}X})", data, data, this->getSize() * 2));
         }
 
         [[nodiscard]] std::string toString() const override {
             auto value = this->getValue();
             auto result = fmt::format("{:d}", value.toUnsigned());
 
-            return Pattern::callUserFormatFunc(result, value, true);
+            return Pattern::callUserFormatFunc(value, true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_wide_character.hpp
+++ b/lib/include/pl/patterns/pattern_wide_character.hpp
@@ -33,7 +33,7 @@ namespace pl::ptrn {
 
             auto result = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>("???").to_bytes(character);
 
-            return Pattern::formatDisplayValue(result, value, true);
+            return Pattern::callUserFormatFunc(result, value, true);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override { return compareCommonProperties<decltype(*this)>(other); }
@@ -43,7 +43,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::formatDisplayValue(fmt::format("'{0}'", this->toString()), this->getValue());
+            return Pattern::callUserFormatFunc(fmt::format("'{0}'", this->toString()), this->getValue());
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_wide_character.hpp
+++ b/lib/include/pl/patterns/pattern_wide_character.hpp
@@ -33,7 +33,7 @@ namespace pl::ptrn {
 
             auto result = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>("???").to_bytes(character);
 
-            return Pattern::callUserFormatFunc(result, value, true);
+            return Pattern::callUserFormatFunc(value, true).value_or(result);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override { return compareCommonProperties<decltype(*this)>(other); }
@@ -43,7 +43,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(fmt::format("'{0}'", this->toString()), this->getValue());
+            return Pattern::callUserFormatFunc(this->getValue()).value_or(fmt::format("'{0}'", this->toString()));
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_wide_string.hpp
+++ b/lib/include/pl/patterns/pattern_wide_string.hpp
@@ -52,7 +52,7 @@ namespace pl::ptrn {
 
             auto result = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>("???").to_bytes(buffer);
 
-            return Pattern::callUserFormatFunc(result, this->getValue(), true);
+            return Pattern::callUserFormatFunc(this->getValue(), true).value_or(result);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override { return compareCommonProperties<decltype(*this)>(other); }
@@ -69,7 +69,7 @@ namespace pl::ptrn {
 
             std::string utf8String = this->getValue(size);
 
-            return Pattern::callUserFormatFunc(fmt::format("\"{0}\" {1}", utf8String, size > this->getSize() ? "(truncated)" : ""), utf8String);
+            return Pattern::callUserFormatFunc(utf8String).value_or(fmt::format("\"{0}\" {1}", utf8String, size > this->getSize() ? "(truncated)" : ""));
         }
 
         [[nodiscard]] std::vector<std::shared_ptr<Pattern>> getEntries() override {

--- a/lib/include/pl/patterns/pattern_wide_string.hpp
+++ b/lib/include/pl/patterns/pattern_wide_string.hpp
@@ -52,7 +52,7 @@ namespace pl::ptrn {
 
             auto result = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>("???").to_bytes(buffer);
 
-            return Pattern::formatDisplayValue(result, this->getValue(), true);
+            return Pattern::callUserFormatFunc(result, this->getValue(), true);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override { return compareCommonProperties<decltype(*this)>(other); }
@@ -69,7 +69,7 @@ namespace pl::ptrn {
 
             std::string utf8String = this->getValue(size);
 
-            return Pattern::formatDisplayValue(fmt::format("\"{0}\" {1}", utf8String, size > this->getSize() ? "(truncated)" : ""), utf8String);
+            return Pattern::callUserFormatFunc(fmt::format("\"{0}\" {1}", utf8String, size > this->getSize() ? "(truncated)" : ""), utf8String);
         }
 
         [[nodiscard]] std::vector<std::shared_ptr<Pattern>> getEntries() override {

--- a/tests/include/test_patterns/test_pattern.hpp
+++ b/tests/include/test_patterns/test_pattern.hpp
@@ -23,7 +23,9 @@ namespace pl::test {
             TestPattern::s_tests.insert({ name, this });
         }
 
-        virtual void setupRuntime(pl::PatternLanguage &runtime) {};
+        PatternLanguage *m_runtime;
+
+        virtual void setup() {};
 
         virtual ~TestPattern() = default;
 

--- a/tests/include/test_patterns/test_pattern_pragmas.hpp
+++ b/tests/include/test_patterns/test_pattern_pragmas.hpp
@@ -11,19 +11,19 @@ namespace pl::test {
         }
         ~TestPatternPragmas() override = default;
 
-        void setupRuntime(pl::PatternLanguage &runtime) {
+        void setup() {
             // All pragmas should be processed the same way, but we test multiple ones to be sure
-            runtime.addPragma("author", [](PatternLanguage&, const std::string &value) {
+            m_runtime->addPragma("author", [](PatternLanguage&, const std::string &value) {
                 return value == "authorValue";
             });
-            runtime.addPragma("description", [](PatternLanguage&, const std::string &value) {
+            m_runtime->addPragma("description", [](PatternLanguage&, const std::string &value) {
                 return value == "descValue";
             });
-            runtime.addPragma("somePragma", [](PatternLanguage&, const std::string &value) {
+            m_runtime->addPragma("somePragma", [](PatternLanguage&, const std::string &value) {
                 return value == "someValue";
             });
             // Also test a pragma which isn't defined in the code, ans whose callback should not be called
-            runtime.addPragma("unknownPragma", [](PatternLanguage&, const std::string &value) {
+            m_runtime->addPragma("unknownPragma", [](PatternLanguage&, const std::string &value) {
                 return false;
             });
         };

--- a/tests/include/test_patterns/test_pattern_pragmas.hpp
+++ b/tests/include/test_patterns/test_pattern_pragmas.hpp
@@ -11,7 +11,7 @@ namespace pl::test {
         }
         ~TestPatternPragmas() override = default;
 
-        void setup() {
+        void setup() override {
             // All pragmas should be processed the same way, but we test multiple ones to be sure
             m_runtime->addPragma("author", [](PatternLanguage&, const std::string &value) {
                 return value == "authorValue";

--- a/tests/include/test_patterns/test_pattern_pragmas_fail.hpp
+++ b/tests/include/test_patterns/test_pattern_pragmas_fail.hpp
@@ -11,8 +11,8 @@ namespace pl::test {
         }
         ~TestPatternPragmasFail() override = default;
 
-        void setupRuntime(pl::PatternLanguage &runtime) {
-            runtime.addPragma("somePragma", [](PatternLanguage&, const std::string &value) {
+        void setup() {
+            m_runtime->addPragma("somePragma", [](PatternLanguage&, const std::string &value) {
                 return value == "invalidValue";
             });
             

--- a/tests/include/test_patterns/test_pattern_pragmas_fail.hpp
+++ b/tests/include/test_patterns/test_pattern_pragmas_fail.hpp
@@ -11,7 +11,7 @@ namespace pl::test {
         }
         ~TestPatternPragmasFail() override = default;
 
-        void setup() {
+        void setup() override {
             m_runtime->addPragma("somePragma", [](PatternLanguage&, const std::string &value) {
                 return value == "invalidValue";
             });

--- a/tests/source/main.cpp
+++ b/tests/source/main.cpp
@@ -105,7 +105,8 @@ int runTests(int argc, char **argv) {
     )", "IC");
 
     auto &test = testPatterns[testName];
-    test->setupRuntime(runtime);
+    test->m_runtime = &runtime;
+    test->setup();
     auto result = runtime.executeString(test->getSourceCode(), "<test: " + testName + ">");
 
     // Check if compilation succeeded


### PR DESCRIPTION
This PR fixes https://github.com/WerWolv/ImHex/issues/1492  by removing the cache sharing, as well as some refactoring/documentation

The cache sharing essentially made Pattern::formatDisplayValue() with 3 args and Pattern::getFormattedValue() exchange return values in some cases, depending on which function was called first in the lifecycle of the program

There shouldn't be any side effect from this, since the cache is still there, now managed fully by Pattern::getFormattedValue()