### PR TITLE
fix: Fix gcc warning

### DIFF
--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -342,7 +342,7 @@ namespace pl::core {
             m_token++;
             tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
             if (tokenLiteral != nullptr && m_token->location.line == line) {
-                message += " " + tokenLiteral->toString(false);
+                message += std::string(" ") + tokenLiteral->toString(false);
                 m_token++;
             }
             error(message);


### PR DESCRIPTION
See https://github.com/p-ranav/argparse/pull/359

Note: this bug only showed up when switching to RelWithDebInfo to Release mode