### PR TITLE
Added check for substrings that span longer than the original string

### DIFF
--- a/lib/source/pl/lib/std/string.cpp
+++ b/lib/source/pl/lib/std/string.cpp
@@ -51,7 +51,9 @@ namespace pl::lib::libstd::string {
                 auto size   = params[2].toUnsigned();
 
                 if (pos > string.length())
-                    err::E0012.throwError(fmt::format("Character index {} out of range of string '{}' with length {}.", pos, string, string.length()));
+                    err::E0012.throwError(fmt::format("The starting position {} out of range for string '{}' with length {}.", pos, string, string.length()));
+                if (pos+size > string.length())
+                    err::E0012.throwError(fmt::format("The ending position {} out of range for string '{}' with length {}.", pos+size, string, string.length()));
 
                 return string.substr(pos, size);
             });


### PR DESCRIPTION
This change follows a discussion that we had on discord. We ended up deciding to modify the behaviour of the `substr` function to throw an error when the requested substring spans further away from the ending of the orignial string.

Thus changind the return value of the functions from:
`[pos, min(pos+count, string.length())]`
to:
`[pos, pos+count]`

This makes the function treat the intial value and ending value the same.

The oposite solution would have been to make the start not throw an error and instead simply return an emptry string.