### PR TITLE
fix: String terminated with newline assigned wrong line to all tokens after.

### DIFF
--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -175,10 +175,18 @@ namespace pl::core {
         m_cursor++; // Skip opening "
 
         while (m_sourceCode[m_cursor] != '\"') {
-            char c = peek();
-            if (c == '\n' || c == '\0') {
+            char c = peek(0);
+            if (c == '\n') {
                 m_errorLength = 1;
-                error(c == '\n' ? "Unexpected newline in string literal" : "Unexpected end of file in string literal");
+                error("Unexpected newline in string literal");
+                m_line++;
+                m_lineBegin = m_cursor;
+                return std::nullopt;
+            }
+
+            if (c == '\0') {
+                m_errorLength = 1;
+                error("Unexpected end of file in string literal");
                 return std::nullopt;
             }
 


### PR DESCRIPTION
When a newline is encountered by the lexer it has to increase the line number and reset `m_lineBegin`. String literals that had a newline before closing double quote were not doing that so all subsequent tokens had the wrong line location.