### PR TITLE
fix: Using the windows path delimiter \ results in error.

### DIFF
--- a/lib/include/pl/core/lexer.hpp
+++ b/lib/include/pl/core/lexer.hpp
@@ -26,7 +26,7 @@ namespace pl::core {
         bool processToken(auto parserFunction, const std::string_view& identifier);
         Location location() override;
 
-        std::optional<char> parseCharacter();
+        std::optional<char> parseCharacter(bool isWindowsPath=false);
         std::optional<Token> parseOperator();
         std::optional<Token> parseSeparator();
         std::optional<Token> parseOneLineComment();
@@ -40,7 +40,7 @@ namespace pl::core {
         std::optional<Token> parseConstant(const std::string_view &identifier);
         std::optional<Token> parseStringLiteral();
         std::optional<Token> parseDirectiveArgument();
-        std::optional<Token> parseDirectiveValue();
+        std::optional<Token> parseDirectiveValue(bool forInclude=false);
         std::optional<Token::Literal> parseIntegerLiteral(std::string_view literal);
 
         std::optional<double> parseFloatingPoint(std::string_view literal, char suffix);

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -52,9 +52,9 @@ namespace pl::core {
     }
 
 
-    std::optional<char> Lexer::parseCharacter() {
+    std::optional<char> Lexer::parseCharacter(bool isWindowsPath) {
         const char& c = m_sourceCode[m_cursor++];
-        if (c == '\\') {
+        if (c == '\\' && !isWindowsPath) {
             switch (m_sourceCode[m_cursor++]) {
                 case 'a':
                     return '\a';
@@ -118,7 +118,7 @@ namespace pl::core {
         return std::nullopt;
     }
 
-    std::optional<Token> Lexer::parseDirectiveValue() {
+    std::optional<Token> Lexer::parseDirectiveValue(bool forInclude) {
         std::string result;
 
         m_cursor++; // Skip space
@@ -126,7 +126,7 @@ namespace pl::core {
 
         while (!std::isblank(m_sourceCode[m_cursor]) && !std::isspace(m_sourceCode[m_cursor]) && m_sourceCode[m_cursor] != '\0' ) {
 
-            auto character = parseCharacter();
+            auto character = parseCharacter(forInclude);
             if (!character.has_value()) {
                 return std::nullopt;
             }
@@ -607,7 +607,7 @@ namespace pl::core {
                         m_cursor++;
                         continue;
                     }
-                    auto directiveValue = parseDirectiveValue();
+                    auto directiveValue = parseDirectiveValue(directive == Token::Directive::Include);
                     if (directiveValue.has_value()) {
                         addToken(directiveValue.value());
                         if (m_line != line || peek(0) == 0)


### PR DESCRIPTION
This can be an issue if you are copying the path directly from explorer. Currently, the old highlighter code changes the color of the char but that will change with the new code. The fix was to add a parameter to the function that processes the directives in the lexer to allow it to skip the escape check.