### PR TITLE
End of program token should specify a size of zero.

### DIFF
--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -661,7 +661,7 @@ namespace pl::core {
             m_cursor++;
         }
 
-        addToken(makeToken(Separator::EndOfProgram));
+        addToken(makeToken(Separator::EndOfProgram,0));
 
         return { m_tokens, collectErrors() };
     }

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -661,7 +661,7 @@ namespace pl::core {
             m_cursor++;
         }
 
-        addToken(makeToken(Separator::EndOfProgram,0));
+        addToken(makeToken(Separator::EndOfProgram, 0));
 
         return { m_tokens, collectErrors() };
     }


### PR DESCRIPTION
The end of program token does not have a character representation, so it is not adding to the number of chars in the input file. Currently, it is set to the default value of 1 which causes a mismatch in the length of the last line.