### PR TITLE
Changes to make syntax highlighting a bit easier.

### DIFF
--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -34,32 +34,55 @@ namespace pl::core {
         void addDirectiveHandler(const Token::Directive &directiveType, const api::DirectiveHandler &handler);
         void removePragmaHandler(const std::string &pragmaType);
         void removeDirectiveHandler(const Token::Directive &directiveType);
-        void validateExcludedLocations();
-        void appendExcludedLocation(const ExcludedLocation &location);
+
         void validateOutput();
 
-        [[nodiscard]] auto getExcludedLocations() const {
+        [[nodiscard]] const std::vector<ExcludedLocation>& getExcludedLocations() const {
             return m_excludedLocations;
         }
 
-        [[nodiscard]] auto getResult() const {
-            return this->m_result;
+        [[nodiscard]] const std::vector<Token>& getResult() {
+            return m_result;
         }
 
         [[nodiscard]] auto getOutput() const {
             return this->m_output;
         }
 
-        void setOutput(std::vector<pl::core::Token> tokens) {
-            m_output = tokens;
+        void setOutput(const std::vector<pl::core::Token> &tokens) {
+            u32 j =0;
+            auto tokenCount = m_result.size();
+            for (auto token : tokens) {
+                if (auto identifier = std::get_if<Token::Identifier>(&token.value); identifier != nullptr) {
+                    if (auto type = identifier->getType(); type > Token::Identifier::IdentifierType::ScopeResolutionUnknown) {
+                        auto location = token.location;
+                        if (location.source->source != "<Source Code>")
+                            continue;
+                        auto line = location.line;
+                        auto column = location.column;
+                        while (m_result[j].location.line < line) {
+                            if (j >= tokenCount)
+                                break;
+                            j++;
+                        }
+                        while (m_result[j].location.column < column) {
+                            if (j >= tokenCount)
+                                break;
+                            j++;
+                        }
+                        if (auto identifier2 = std::get_if<Token::Identifier>(&m_result[j].value); identifier2 != nullptr)
+                            identifier2->setType(type);
+                    }
+                }
+            }
         }
 
-        [[nodiscard]] auto getErrors() const {
-            return this->m_errors;
+        [[nodiscard]] const std::vector<err::CompileError>& getStoredErrors() const {
+            return this->m_storedErrors;
         }
 
-        void setErrors(std::vector<err::CompileError> errors) {
-            m_errors = errors;
+        void setStoredErrors(const std::vector<err::CompileError> &errors) {
+            m_storedErrors = errors;
         }
 
         [[nodiscard]] bool shouldOnlyIncludeOnce() const {
@@ -70,11 +93,15 @@ namespace pl::core {
             return m_initialized;
         }
 
-        void setResolver(const api::Resolver& resolvers) {
+        [[nodiscard]] const api::Resolver& getResolver() const {
+            return m_resolver;
+        }
+
+        void setResolver(const api::Resolver &resolvers) {
             m_resolver = resolvers;
         }
 
-        auto getNamespaces() const {
+        const std::vector<std::string> &getNamespaces() const {
             return m_namespaces;
         }
 
@@ -114,7 +141,7 @@ namespace pl::core {
         std::vector<Token> m_keys;
         std::atomic<bool> m_initialized = false;
         std::vector<Token>::iterator m_token;
-        std::vector<err::CompileError> m_errors;
+        std::vector<err::CompileError> m_storedErrors;
         std::vector<Token> m_result;
         std::vector<Token> m_output;
         std::vector<std::string> m_namespaces;

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -117,7 +117,7 @@ namespace pl {
         }
 
 
-        this->m_internals.preprocessor->setErrors(this->m_compileErrors);
+        this->m_internals.preprocessor->setStoredErrors(this->m_compileErrors);
 
         if (ast->empty() || !ast.has_value())
             return std::nullopt;


### PR DESCRIPTION
- Namespaces that are found in included files are not labeled by parser.  Look for the namespace keyword to find all. 
- Locations excluded by `#ifdef` cannot repeat, and it doesn't make sense to validate them, so I removed the functions that were appending and validating them. 
- Initially, syntax highlighting needed to have access to two set of tokens. The un-preprocessed token sequence contains directives and comments that need to be highlighted. The preprocessed token sequence is used by the parser which adds identifier types to variable definitions. Instead of passing two very similar sets of tokens, the original ones are merged into one by assigning the information added by the parser to the un-preprocessed tokens. 
- Other changes include corrections to arguments missing reference operators and name changes to un-shadow names of inherited functions. It should be self-explanatory.