### PR TITLE
fix: Broken #pragma once on import

### DIFF
--- a/lib/include/pl/core/parser_manager.hpp
+++ b/lib/include/pl/core/parser_manager.hpp
@@ -45,7 +45,9 @@ namespace pl::core {
             std::string alias;
 
             auto operator<=>(const OnceIncludePair& other) const {
-                return std::tie(*this->source, this->alias) <=> std::tie(*other.source, other.alias);
+                auto sourcePtr = reinterpret_cast<uintptr_t>(source);
+                auto otherSourcePtr = reinterpret_cast<uintptr_t>(other.source);
+                return std::tie(sourcePtr, this->alias) <=> std::tie(otherSourcePtr, other.alias);
             }
         };
 


### PR DESCRIPTION
## Issue description

`import`ing a `#pragma once` marked file multiple times results in multiple evaluation. (E.g. having a variable will throw an error for multiple definitions)

## Issue cause
Already included files marked with #pragma once are stored in a std::set with key of custom type OnceIncludePair. The type overrides spaceship operator for map/set comparison, but uses data from api::Source pointer.  The api::Source pointer is a pointer to a map element, which is stored to keep one instance for all loaded files from the same path.
The issue hides in the fact that default resolver [stores the instance through insert_or_assign](https://github.com/WerWolv/PatternLanguage/blob/188a8089a8f23d0cdacc0f6c38384e4f8fe93ef1/lib/source/pl/core/resolver.cpp#L25) which replaces the old data at this pointer with the new one, with a different ID. Since old comparison used IDs when added to a onceIncluded set, and the ID is now different, set order is not valid anymore, breaking set::contains and potentially other set operations.

## Proposed solution
This PR compares api::Source pointers directly, instead of IDs inside of them. This ensures that no data inside will change (and therefore won't break set/map structure), while still keeping the functionality, since the pointer doesn't change.