### PR TITLE
Fix native build support for macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-stringop-overflow -Wno-dangling-reference -fexceptions -frtti")
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -fexceptions -frtti")
 elseif (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"))
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-array-bounds")

--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -70,6 +70,13 @@ namespace pl::core {
         };
 
         struct Scope {
+            Scope(const std::shared_ptr<pl::ptrn::Pattern>& parentPattern,
+                std::vector<std::shared_ptr<pl::ptrn::Pattern>>* scopePatterns,
+                unsigned long heapSize)
+                : parent(parentPattern),
+                scope(scopePatterns),
+                heapStartSize(heapSize) {}
+
             std::shared_ptr<ptrn::Pattern> parent;
             std::vector<std::shared_ptr<ptrn::Pattern>> *scope;
             std::optional<ParameterPack> parameterPack;

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -755,7 +755,7 @@ namespace pl::core {
 
         const auto &heap = this->getHeap();
 
-        this->m_scopes.emplace_back(std::make_unique<Scope>(parent, &scope, std::nullopt, heap.size()));
+        this->m_scopes.emplace_back(std::make_unique<Scope>(parent, &scope, heap.size()));
 
         if (this->isDebugModeEnabled())
             this->getConsole().log(LogConsole::Level::Debug, fmt::format("Entering new scope #{}. Parent: '{}', Heap Size: {}.", this->m_scopes.size(), parent == nullptr ? "None" : parent->getVariableName(), heap.size()));


### PR DESCRIPTION
# Summary
This pull request addresses build issues related to deprecated functions and improves compatibility with different C++ compilers. The changes primarily include modifying the CMakeLists.txt to suppress deprecated warnings for both Clang and AppleClang compilers and updating the project source code to resolve errors caused by constructor mismatches.

I'm on an M1 MacBook Pro
version 14.6.1 (23G93)

and I'm building this way:
```
cmake -B build
cmake --build build -- -j$(sysctl -n hw.ncpu)
```

## Key Changes
### 1. Suppress Deprecated Warnings in CMake:
- Enhanced `CMakeLists.txt` to handle both Clang and AppleClang compilers by adding a condition to suppress deprecated warnings.

### 2. Fixed Constructor Mismatch in `Scope` Struct:
- Updated the `Scope` struct constructor to match the parameters provided during its instantiation.
- Removed inappropriate usage of `std::optional<std::nullopt_t>`.