### PR TITLE
Set types for breakpoints correctly.

### DIFF
--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -362,11 +362,12 @@ namespace pl::core {
 
         [[nodiscard]] Evaluator::UpdateHandler updateRuntime(const ast::ASTNode *node);
 
-        void addBreakpoint(u64 line);
-        void removeBreakpoint(u64 line);
+        void addBreakpoint(u32 line);
+        void removeBreakpoint(u32 line);
         void clearBreakpoints();
         void setBreakpointHitCallback(const std::function<void()> &callback);
-        const std::unordered_set<int>& getBreakpoints() const;
+        void setBreakpoints(const std::unordered_set<u32>& breakpoints);
+        const std::unordered_set<u32>& getBreakpoints() const;
         void pauseNextLine();
         std::optional<u32> getPauseLine() const;
 
@@ -464,7 +465,7 @@ namespace pl::core {
 
         std::optional<u64> m_currArrayIndex;
 
-        std::unordered_set<int> m_breakpoints;
+        std::unordered_set<u32> m_breakpoints;
         std::optional<u32> m_lastPauseLine;
         bool m_shouldPauseNextLine = false;
 

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -1130,11 +1130,12 @@ namespace pl::core {
         return { this, node };
     }
 
-    void Evaluator::addBreakpoint(u64 line) { this->m_breakpoints.insert(line); }
-    void Evaluator::removeBreakpoint(u64 line) { this->m_breakpoints.erase(line); }
+    void Evaluator::addBreakpoint(u32 line) { this->m_breakpoints.insert(line); }
+    void Evaluator::removeBreakpoint(u32 line) { this->m_breakpoints.erase(line); }
     void Evaluator::clearBreakpoints() { this->m_breakpoints.clear(); }
     void Evaluator::setBreakpointHitCallback(const std::function<void()> &callback) { this->m_breakpointHitCallback = callback; }
-    const std::unordered_set<int> &Evaluator::getBreakpoints() const { return this->m_breakpoints; }
+    const std::unordered_set<u32> &Evaluator::getBreakpoints() const { return this->m_breakpoints; }
+    void Evaluator::setBreakpoints(const std::unordered_set<u32> &breakpoints) { m_breakpoints = breakpoints; }
     void Evaluator::pauseNextLine() { this->m_shouldPauseNextLine = true; }
 
     std::optional<u32> Evaluator::getPauseLine() const {


### PR DESCRIPTION
Currently, functions that handle breakpoints are using three types of variables for the line number they are located at; u64, u32 and int. This PR aims at making all the functions that use breakpoints use only u32 values for the line numbers. Also added a function for setting breakpoints used for fixing problems with breakpoints.