### PR TITLE
improv: Unified pragma once system for imports and includes.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -71,7 +71,6 @@ add_library(libpl ${LIBRARY_TYPE}
         source/pl/lib/std/hash.cpp
         source/pl/lib/std/random.cpp
         source/pl/core/resolvers.cpp
-        source/pl/core/api.cpp
 )
 
 if (LIBPL_ENABLE_PRECOMPILED_HEADERS)

--- a/lib/include/pl/api.hpp
+++ b/lib/include/pl/api.hpp
@@ -3,13 +3,13 @@
 #include <pl/core/token.hpp>
 #include <pl/core/errors/result.hpp>
 #include <pl/helpers/types.hpp>
+#include <pl/helpers/utils.hpp>
 
 #include <cmath>
 #include <vector>
 #include <functional>
 #include <string>
 #include <optional>
-#include "pl/helpers/utils.hpp"
 
 namespace pl {
 

--- a/lib/include/pl/api.hpp
+++ b/lib/include/pl/api.hpp
@@ -44,7 +44,7 @@ namespace pl::api {
 
          Source(std::string content, std::string source = DefaultSource, bool mainSource = false) :
             content(std::move(content)), source(std::move(source)), mainSource(mainSource) {
-            this->id = pl::hlp::stringCrc32(source);
+            this->id = pl::hlp::stringCrc32(this->source);
         }
 
         Source() = default;

--- a/lib/include/pl/api.hpp
+++ b/lib/include/pl/api.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <string>
 #include <optional>
+#include "pl/helpers/utils.hpp"
 
 namespace pl {
 
@@ -31,6 +32,7 @@ namespace pl::api {
     using PragmaHandler = std::function<bool(PatternLanguage&, const std::string &)>;
 
     using DirectiveHandler = std::function<void(core::Preprocessor*, u32)>;
+    using StatementHandler = std::function<void(core::Preprocessor*, u32)>;
 
     using Resolver = std::function<hlp::Result<Source*, std::string>(const std::string&)>;
 
@@ -40,10 +42,10 @@ namespace pl::api {
         u32 id = 0;
         bool mainSource;
 
-        static u32 idCounter;
-
-        Source(std::string content, std::string source = DefaultSource, bool mainSource = false) :
-            content(std::move(content)), source(std::move(source)), id(idCounter++), mainSource(mainSource) { }
+         Source(std::string content, std::string source = DefaultSource, bool mainSource = false) :
+            content(std::move(content)), source(std::move(source)), mainSource(mainSource) {
+            this->id = pl::hlp::stringCrc32(source);
+        }
 
         Source() = default;
 

--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -212,6 +212,8 @@ namespace pl::core {
 
         hlp::safe_shared_ptr<ast::ASTNodeTypeDecl> addType(const std::string &name, hlp::safe_unique_ptr<ast::ASTNode> &&node, std::optional<std::endian> endian = std::nullopt);
 
+        void includeGuard();
+
         std::vector<hlp::safe_shared_ptr<ast::ASTNode>> parseTillToken(const Token &endToken) {
             std::vector<hlp::safe_shared_ptr<ast::ASTNode>> program;
 

--- a/lib/include/pl/core/parser_manager.hpp
+++ b/lib/include/pl/core/parser_manager.hpp
@@ -39,7 +39,6 @@ namespace pl::core {
             this->m_parsedTypes.clear();
         }
 
-    private:
         struct OnceIncludePair {
             api::Source* source;
             std::string alias;
@@ -48,9 +47,13 @@ namespace pl::core {
                 return std::tie(*this->source, this->alias) <=> std::tie(*other.source, other.alias);
             }
         };
-
+        std::set<OnceIncludePair> & getOnceIncluded() { return m_onceIncluded; }
+        std::set<OnceIncludePair> & getPreprocessorOnceIncluded() { return m_preprocessorOnceIncluded; }
+        void setPreprocessorOnceIncluded(const std::set<OnceIncludePair>& onceIncluded) { m_preprocessorOnceIncluded = onceIncluded; }
+private:
         std::map<OnceIncludePair, std::map<std::string, hlp::safe_shared_ptr<ast::ASTNodeTypeDecl>>> m_parsedTypes {};
         std::set<OnceIncludePair> m_onceIncluded {};
+        std::set<OnceIncludePair> m_preprocessorOnceIncluded {};
         api::Resolver m_resolver = nullptr;
         PatternLanguage* m_patternLanguage = nullptr;
     };

--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -10,11 +10,11 @@
 #include <pl/api.hpp>
 #include <pl/helpers/types.hpp>
 #include <pl/core/errors/error.hpp>
+#include <pl/core/parser.hpp>
 
 #include <pl/core/errors/result.hpp>
 
 #include <utility>
-#include "parser.hpp"
 
 namespace pl::core {
 

--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -14,6 +14,7 @@
 #include <pl/core/errors/result.hpp>
 
 #include <utility>
+#include "parser.hpp"
 
 namespace pl::core {
 
@@ -32,6 +33,7 @@ namespace pl::core {
         void addDefine(const std::string &name, const std::string &value = "");
         void addPragmaHandler(const std::string &pragmaType, const api::PragmaHandler &handler);
         void addDirectiveHandler(const Token::Directive &directiveType, const api::DirectiveHandler &handler);
+        void addStatementHandler(const Token::Keyword &statementType, const api::StatementHandler &handler);
         void removePragmaHandler(const std::string &pragmaType);
         void removeDirectiveHandler(const Token::Directive &directiveType);
         void validateExcludedLocations();
@@ -78,6 +80,10 @@ namespace pl::core {
             return m_namespaces;
         }
 
+        const auto &getOnceIncludedFiles() const {
+            return m_onceIncludedFiles;
+        }
+
         void appendToNamespaces(std::vector<Token> tokens);
 
     private:
@@ -85,6 +91,7 @@ namespace pl::core {
         bool eof();
         Location location() override;
         void removeKey(const Token &token);
+        void nextLine(u32 line);
         // directive handlers
         void handleIfDef(u32 line);
         void handleIfNDef(u32 line);
@@ -92,21 +99,24 @@ namespace pl::core {
         void handleUnDefine(u32 line);
         void handlePragma(u32 line);
         void handleInclude(u32 line);
+        void handleImport(u32 line);
         void handleError(u32 line);
 
         void process();
         void processIfDef(bool add);
 
         void registerDirectiveHandler(const Token::Directive &name, auto memberFunction);
+        void registerStatementHandler(const Token::Keyword &name, auto memberFunction);
 
         std::unordered_map<std::string, api::PragmaHandler> m_pragmaHandlers;
         std::unordered_map<Token::Directive, api::DirectiveHandler> m_directiveHandlers;
+        std::unordered_map<Token::Keyword, api::StatementHandler> m_statementHandlers;
 
         std::unordered_map<std::string, std::vector<Token>> m_defines;
         std::unordered_map<std::string, std::vector<std::pair<std::string, u32>>> m_pragmas;
         std::vector<ExcludedLocation> m_excludedLocations;
 
-        std::set<std::string> m_onceIncludedFiles;
+        std::set<pl::core::ParserManager::OnceIncludePair> m_onceIncludedFiles;
 
         api::Resolver m_resolver = nullptr;
         PatternLanguage *m_runtime = nullptr;

--- a/lib/include/pl/helpers/utils.hpp
+++ b/lib/include/pl/helpers/utils.hpp
@@ -49,6 +49,8 @@ namespace pl::hlp {
     }
 
     std::string encodeByteString(const std::vector<u8> &bytes);
+    std::vector<u8> decodeByteString(const std::string &str);
+    u32 stringCrc32(const std::string &str);
 
     [[nodiscard]] constexpr inline i128 signExtend(size_t numBits, i128 value) {
         i128 mask = u128(1) << u128(numBits - 1);

--- a/lib/source/pl/core/api.cpp
+++ b/lib/source/pl/core/api.cpp
@@ -1,7 +1,0 @@
-#include <pl/api.hpp>
-
-namespace pl::api {
-
-    u32 Source::idCounter;
-
-}

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -2514,8 +2514,9 @@ namespace pl::core {
     }
 
     void Parser::includeGuard() {
-        if (m_curr->location.source->source == "<Source Code")
+        if (m_curr->location.source->source == "<Source Code>")
             return;
+        
         ParserManager::OnceIncludePair key = {const_cast<api::Source *>(m_curr->location.source), ""};
         if (m_parserManager->getPreprocessorOnceIncluded().contains(key))
             m_parserManager->getOnceIncluded().insert(key);

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -2513,12 +2513,22 @@ namespace pl::core {
         return nullptr;
     }
 
+    void Parser::includeGuard() {
+        if (m_curr->location.source->source == "<Source Code")
+            return;
+        ParserManager::OnceIncludePair key = {const_cast<api::Source *>(m_curr->location.source), ""};
+        if (m_parserManager->getPreprocessorOnceIncluded().contains(key))
+            m_parserManager->getOnceIncluded().insert(key);
+    }
+
     /* Program */
 
     // <(parseUsingDeclaration)|(parseVariablePlacement)|(parseStruct)>
     std::vector<hlp::safe_shared_ptr<ast::ASTNode>> Parser::parseStatements() {
         hlp::safe_shared_ptr<ast::ASTNode> statement;
         bool requiresSemicolon = true;
+
+        includeGuard();
 
         if (const auto docComment = parseDocComment(true); docComment.has_value())
             this->addGlobalDocComment(docComment->comment);

--- a/lib/source/pl/core/parser_manager.cpp
+++ b/lib/source/pl/core/parser_manager.cpp
@@ -15,8 +15,7 @@ Result ParserManager::parse(api::Source *source, const std::string &namespacePre
 
     if (m_onceIncluded.contains( key )) {
         const auto& types = m_parsedTypes[key];
-        if (!types.empty())
-            return Result::good({ {}, types });
+        return Result::good({ {}, types }); // Even if types is empty we still need to return now
     }
 
     Parser parser;

--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -26,6 +26,7 @@ namespace pl::core {
         registerDirectiveHandler(Token::Directive::Pragma, &Preprocessor::handlePragma);
         registerDirectiveHandler(Token::Directive::Include, &Preprocessor::handleInclude);
         registerDirectiveHandler(Token::Directive::Error, &Preprocessor::handleError);
+        registerStatementHandler(Token::Keyword::Import, &Preprocessor::handleImport);
     }
 
     Preprocessor::Preprocessor(const Preprocessor &other) : ErrorCollector(other) {
@@ -36,6 +37,7 @@ namespace pl::core {
         this->m_onlyIncludeOnce = false;
         this->m_pragmaHandlers = other.m_pragmaHandlers;
         this->m_directiveHandlers = other.m_directiveHandlers;
+        this->m_statementHandlers = other.m_statementHandlers;
         this->m_keys = other.m_keys;
         this->m_initialized = false;
 
@@ -70,6 +72,16 @@ namespace pl::core {
                 return false;
         }
         return true;
+    }
+
+    void Preprocessor::nextLine(u32 line) {
+        while (!eof() && m_token->location.line == line) {
+            if (auto *separator = std::get_if<Token::Separator>(&m_token->value);
+                    (separator != nullptr && *separator == Token::Separator::EndOfProgram) ||
+                    m_token->type == Token::Type::Comment || m_token->type == Token::Type::DocComment)
+                m_output.push_back(*m_token);
+            m_token++;
+        }
     }
 
     void Preprocessor::removeKey(const Token &token) {
@@ -218,30 +230,23 @@ namespace pl::core {
     void Preprocessor::handleInclude(u32 line) {
         // get include name
         auto *tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
-        if (tokenLiteral == nullptr || m_token->location.line != line) {
+        std::string path;
+        if (tokenLiteral != nullptr && m_token->type == Token::Type::String) {
+            path = tokenLiteral->toString(false);
+            if (path.contains('.'))
+                path = wolv::util::replaceStrings(path, ".", "/");
+        } else if (tokenLiteral == nullptr || m_token->location.line != line) {
             errorDesc("No file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
             return;
         }
-        auto includeFile = tokenLiteral->toString(false);
         m_token++;
-
-        if (!(includeFile.starts_with('"') && includeFile.ends_with('"')) && !(includeFile.starts_with('<') && includeFile.ends_with('>'))) {
-            errorDesc("Invalid file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
-            return;
-        }
-
-        const std::string includePath = includeFile.substr(1, includeFile.length() - 2);
-
-        // determine if we should include this file
-        if (this->m_onceIncludedFiles.contains(includePath))
-            return;
 
         if(!m_resolver) {
             errorDesc("Unable to lookup results", "No include resolver was set.");
             return;
         }
 
-        auto [resolved, error] = this->m_resolver(includePath);
+        auto [resolved, error] = this->m_resolver(path);
 
         if(!resolved.has_value()) {
             for (const auto &item: error) {
@@ -249,6 +254,9 @@ namespace pl::core {
             }
             return;
         }
+        // determine if we should include this file
+        if (this->m_onceIncludedFiles.contains({resolved.value(),""}))
+            return;
 
         Preprocessor preprocessor(*this);
         preprocessor.m_pragmas.clear();
@@ -264,7 +272,7 @@ namespace pl::core {
 
         bool shouldInclude = true;
         if (preprocessor.shouldOnlyIncludeOnce()) {
-            auto [iter, added] = this->m_onceIncludedFiles.insert(includePath);
+            auto [iter, added] = this->m_onceIncludedFiles.insert({resolved.value(), ""});
             if (!added) {
                 shouldInclude = false;
             }
@@ -289,18 +297,127 @@ namespace pl::core {
         }
     }
 
+    void Preprocessor::handleImport(u32 line) {
+        std::vector<Token> saveImport;
+        saveImport.push_back(m_token[-1]);
+        saveImport.push_back(*m_token);
+        // get include name
+        auto *tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
+        std::string path;
+        if (m_token->type == Token::Type::String) {
+            path = tokenLiteral->toString(false);
+        } else if (m_token->type == Token::Type::Identifier) {
+            path = std::get_if<Token::Identifier>(&m_token->value)->get();
+            m_token++;
+            auto *separator = std::get_if<Token::Separator>(&m_token->value);
+            while (separator != nullptr && *separator == Token::Separator::Dot) {
+                saveImport.push_back(*m_token);
+                m_token++;
+                if (m_token->type != Token::Type::Identifier) {
+                    error("Expected identifier after '.' in import statement.");
+                    return;
+                }
+                path += "/" + std::get_if<Token::Identifier>(&m_token->value)->get();
+                saveImport.push_back(*m_token);
+                m_token++;
+                separator = std::get_if<Token::Separator>(&m_token->value);
+            }
+        } else {
+            errorDesc("No file to import given in import statement.", "An import statement expects a path to a file: import path.to.file; or import \"path/to/file\".");
+            return;
+        }
+        std::string alias;
+        if (auto *keyword = std::get_if<Token::Keyword>(&m_token->value); keyword != nullptr && *keyword == Token::Keyword::As) {
+            saveImport.push_back(*m_token);
+            m_token++;
+            if (m_token->type != Token::Type::Identifier) {
+                error("Expected identifier after 'as' in import statement.");
+                return;
+            }
+            alias = std::get_if<Token::Identifier>(&m_token->value)->get();
+            saveImport.push_back(*m_token);
+            m_token++;
+        }
+
+        auto *separator = std::get_if<Token::Separator>(&m_token->value);
+        if (separator == nullptr || *separator != Token::Separator::Semicolon) {
+            errorDesc("No semicolon found after import statement.", "An import statement expects a semicolon at the end: import path.to.file;");
+            return;
+        }
+        saveImport.push_back(*m_token);
+        m_token++;
+        if(!m_resolver) {
+            errorDesc("Unable to lookup results", "No include resolver was set.");
+            return;
+        }
+
+        auto [resolved, error] = this->m_resolver(path);
+
+        if(!resolved.has_value()) {
+            for (const auto &item: error) {
+                this->error(item);
+            }
+            return;
+        }
+        // determine if we should include this file
+        if (this->m_onceIncludedFiles.contains({resolved.value(),alias}))
+            return;
+
+
+        Preprocessor preprocessor(*this);
+        preprocessor.m_pragmas.clear();
+
+        auto result = preprocessor.preprocess(m_runtime, resolved.value(), false);
+
+        if (result.hasErrs()) {
+            for (auto &item: result.errs) {
+                this->error(item);
+            }
+            return;
+        }
+
+        bool shouldInclude = true;
+        if (preprocessor.shouldOnlyIncludeOnce()) {
+            auto [iter, added] = this->m_onceIncludedFiles.insert({resolved.value(), alias});
+            if (!added) {
+                shouldInclude = false;
+            }
+        }
+
+        std::ranges::copy(preprocessor.m_onceIncludedFiles.begin(), preprocessor.m_onceIncludedFiles.end(), std::inserter(this->m_onceIncludedFiles, this->m_onceIncludedFiles.begin()));
+
+        if (shouldInclude) {
+          for (auto entry : saveImport) {
+              m_output.push_back(entry);
+          }
+        }
+        nextLine(line);
+    }
+
     void Preprocessor::process() {
         u32 line = m_token->location.line;
 
         if (auto *directive = std::get_if<Token::Directive>(&m_token->value); directive != nullptr ) {
             auto handler = m_directiveHandlers.find(*directive);
-            if(handler == m_directiveHandlers.end()) {
+            if (handler == m_directiveHandlers.end()) {
                 error("Unknown directive '{}'", m_token->getFormattedValue());
                 m_token++;
                 return;
             } else {
                 m_token++;
                 handler->second(this, line);
+            }
+
+        } else  if (auto *statement = std::get_if<Token::Keyword>(&m_token->value); statement != nullptr && *statement == Token::Keyword::Import) {
+            auto handler = m_statementHandlers.find(*statement);
+            if (handler == m_statementHandlers.end()) {
+                error("Unknown statement '{}'", m_token->getFormattedValue());
+                m_token++;
+                return;
+            } else {
+                m_token++;
+                handler->second(this, line);
+                nextLine(line);
             }
 
         } else if (m_token->type == Token::Type::Comment)
@@ -476,6 +593,10 @@ namespace pl::core {
         this->m_directiveHandlers[directiveType] = handler;
     }
 
+    void Preprocessor::addStatementHandler(const Token::Keyword &statementType, const api::StatementHandler &handler) {
+        this->m_statementHandlers[statementType] = handler;
+    }
+
     void Preprocessor::removePragmaHandler(const std::string &pragmaType) {
         this->m_pragmaHandlers.erase(pragmaType);
     }
@@ -497,6 +618,11 @@ namespace pl::core {
             return token->location;
         } else
             return { nullptr, 0, 0, 0 };
+    }
+    void Preprocessor::registerStatementHandler(const Token::Keyword &name, auto memberFunction) {
+        this->m_statementHandlers[name] = [memberFunction](Preprocessor* preprocessor, u32 line){
+            (preprocessor->*memberFunction)(line);
+        };
     }
 
     void Preprocessor::registerDirectiveHandler(const Token::Directive& name, auto memberFunction) {

--- a/lib/source/pl/helpers/utils.cpp
+++ b/lib/source/pl/helpers/utils.cpp
@@ -3,7 +3,7 @@
 #include <codecvt>
 
 #include <fmt/format.h>
-#include "wolv/hash/crc.hpp"
+#include <wolv/hash/crc.hpp>
 
 namespace pl::hlp {
 

--- a/lib/source/pl/helpers/utils.cpp
+++ b/lib/source/pl/helpers/utils.cpp
@@ -3,6 +3,7 @@
 #include <codecvt>
 
 #include <fmt/format.h>
+#include "wolv/hash/crc.hpp"
 
 namespace pl::hlp {
 
@@ -12,6 +13,15 @@ namespace pl::hlp {
 
     std::string to_string(i128 value) {
         return fmt::format("{}", value);
+    }
+
+    std::vector<u8> decodeByteString(const std::string &str) {
+        std::vector<u8> result;
+
+        for (size_t i = 0; i < str.size(); i++)
+            result.push_back(str[i]);
+
+        return result;
     }
 
     std::string encodeByteString(const std::vector<u8> &bytes) {
@@ -54,6 +64,14 @@ namespace pl::hlp {
         }
 
         return result;
+    }
+
+    u32 stringCrc32(const std::string &str) {
+        wolv::hash::Crc<32> crc32(0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true);
+
+        crc32.process(decodeByteString(str));
+
+        return crc32.getResult();
     }
 
     float float16ToFloat32(u16 float16) {

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -95,6 +95,8 @@ namespace pl {
         if (!tokens.has_value() || tokens->empty())
             return std::nullopt;
 
+        this->m_parserManager.setPreprocessorOnceIncluded(this->m_internals.preprocessor->getOnceIncludedFiles());
+        this->m_internals.parser->setParserManager(&this->m_parserManager);
         auto [ast, parserErrors] = this->m_internals.parser->parse(tokens.value());
         if (!parserErrors.empty()) {
             this->m_compileErrors.insert(m_compileErrors.end(), parserErrors.begin(), parserErrors.end());


### PR DESCRIPTION
- fix: certain combinations of mixing imports and includes could cause strange and unexpected errors. A large part of the problem was that a file that was both included and imported ended up as two files with different ids.

- improv: includes now support the dot style path specification that import uses.

- fix: fixed bug that pr 128 of the pattern language repo claimed to have fixed but actually did not. The bug was that if a file that defined no types but instantiated some variable was included or imported twice, then a duplicate variable error will be generated. The error was created when, after checking if file was included once, The AST was generated because the size of the types was zero. The AST contains the instantiations of variables which are duplicated generating the error.

### Implementation details
In terms of data types there were two major changes. The first is how source ids are calculated. The old method of increasing a static variable doesn't guarantee that the same path always leads to the same id. The file ids are now calculated using crc32 on the full path file name which turns the uncertainty into certainty.

The second change involves the variable types for onceIncluded and onceIncludedFiles. Instead of storing once included files in sets of integers, include files now use the same data type than imports uses.

### Description
A file that is imported earlier that has pragma once can block the inclusion of the same file later on. so we need to record which files are imported during preprocessing but only to determine what includes, if any, are affected by them. 

To allow includes to block imports, we use the once included files list generated during preprocessing to place entries in the once included file list generated during parsing when the tokens that resulted from the inclusion are being parsed.This way subsequent imports of the same file will be blocked by the includes. 

To fix the bug mentioned in pr #128 we remove the check of an empty types vector and returns what can possibly be an empty string. 

These changes were tested using a file that imported/included another file which was imported/included first. The tests checked all combinations of import vs. include both with and without  pragma once and produced expected results in all cases. 

Some changes in this pr are also part of prs that have been waiting to be reviewed for a while now in order to avoid conflicts that would occur regardless of the order in which they are merged.