### PR TITLE
fix: accumulate math function didn't work.

### DIFF
--- a/lib/source/pl/lib/std/math.cpp
+++ b/lib/source/pl/lib/std/math.cpp
@@ -175,13 +175,12 @@ namespace pl::lib::libstd::math {
                     err::E0003.throwError("Size cannot be bigger than sizeof(u128)", {});
  
                 u128 result = 0;
-                u128 endAddr = end / size;
 
                 auto reader = hlp::MemoryReader(ctx, section);
                 reader.seek(start);
                 reader.setEndAddress(end);
 
-                for (u128 addr = start; addr < endAddr; ++addr) {
+                for (u128 addr = start; addr < end; addr += size) {
                     auto bytes = reader.read(addr, size);
 
                     // Copy bytes to u128


### PR DESCRIPTION
The function used to perform operations on sets of data only worked for 8 bit data types. The number of operations was set correctly, but the pointer only incremented one byte at a time.

The pointer now advances the size of the data type in bytes and the end condition of the loop is changed accordingly.