### PR TITLE
Undo import-like syntax support for includes.

### DIFF
--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -233,21 +233,18 @@ namespace pl::core {
     void Preprocessor::handleInclude(u32 line) {
         // get include name
         auto *tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
-        std::string path;
-        if (tokenLiteral != nullptr && m_token->type == Token::Type::String) {
-            path = tokenLiteral->toString(false);
-
-            const bool isInclude = (path.starts_with('"') && path.ends_with('"')) || (path.starts_with('<') && path.ends_with('>'));
-
-            if (isInclude) {
-                path = path.substr(1, path.length() - 2);
-            } else {
-                path = wolv::util::replaceStrings(path, ".", "/");
-            }
-        } else if (tokenLiteral == nullptr || m_token->location.line != line) {
+        if (tokenLiteral == nullptr || m_token->location.line != line ||  m_token->type != Token::Type::String) {
             errorDesc("No file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
             return;
         }
+        auto path = tokenLiteral->toString(false);
+        if (!(path.starts_with('"') && path.ends_with('"')) && !(path.starts_with('<') && path.ends_with('>'))) {
+            errorDesc("Invalid file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
+            return;
+        }
+
+        path = path.substr(1, path.length() - 2);
+
         m_token++;
 
         if(!m_resolver) {


### PR DESCRIPTION
Just like imports can use include-like syntax I tried to make includes support import-like syntax. That way the choice would depend less on the format and more on the capabilities of each implementation. I got the distinct impression that it wasn't a good idea and on top of that I screwed up and made includes unusable. Luckily Werwolv came to the rescue and fixed the bad code but what's left is hard to read because it still contains code to support import syntax while not supporting it anymore.

So I've decided to write code that support only the original syntax of includes so these are correct:
```cpp
#include "std/io.pat"
#include "std/io"
#include "std/io"
#include "std\\io" //on windows only
#include <std/io.pat>
```
and so that these forms don't work
```cpp
#include "std.io"
#include <std.io>
```
and so on.
Hopefully this makes the code make a bit more sense and work as expected. At least it has in all the tests I've done.