### PR TITLE
Prioritise local parameters over template parameters in AST node rvalue evaluation

### DIFF
--- a/lib/source/pl/core/ast/ast_node_rvalue.cpp
+++ b/lib/source/pl/core/ast/ast_node_rvalue.cpp
@@ -163,13 +163,13 @@ namespace pl::core::ast {
         }
 
         {
-            const auto &currScope = evaluator->getScope(0);
-            std::copy(currScope.scope->begin(), currScope.scope->end(), std::back_inserter(searchScope));
+            const auto &templateParameters = evaluator->getTemplateParameters();
+            std::copy(templateParameters.begin(), templateParameters.end(), std::back_inserter(searchScope));
         }
 
         {
-            const auto &templateParameters = evaluator->getTemplateParameters();
-            std::copy(templateParameters.begin(), templateParameters.end(), std::back_inserter(searchScope));
+            const auto &currScope = evaluator->getScope(0);
+            std::copy(currScope.scope->begin(), currScope.scope->end(), std::back_inserter(searchScope));
         }
 
         for (const auto &part : this->getPath()) {


### PR DESCRIPTION
- fix #146

Unsure if it will break the existing pattern. Is there any case where the original behavior is preferred?