### PR TITLE
Error markers we displayed in the wrong place.

### DIFF
--- a/lib/include/pl/core/lexer.hpp
+++ b/lib/include/pl/core/lexer.hpp
@@ -20,6 +20,8 @@ namespace pl::core {
         Lexer() = default;
 
         hlp::CompileResult<std::vector<Token>> lex(const api::Source *source);
+        size_t getLongestLineLength() const { return m_longestLineLength; }
+
 
     private:
         [[nodiscard]] char peek(size_t p = 1) const;
@@ -49,13 +51,16 @@ namespace pl::core {
         Token makeToken(const Token& token, size_t length = 1);
         static Token makeTokenAt(const Token& token, Location& location, size_t length = 1);
         void addToken(const Token& token);
-
+        size_t compareCurrentWithLongest() const {
+            return std::max(m_longestLineLength, m_cursor - m_lineBegin);
+        }
         std::string m_sourceCode;
         const api::Source* m_source = nullptr;
         std::vector<Token> m_tokens;
         size_t m_cursor = 0;
         u32 m_line = 0;
         u32 m_lineBegin = 0;
+        size_t m_longestLineLength = 0;
         u32 m_errorLength;
     };
 }

--- a/lib/include/pl/core/lexer.hpp
+++ b/lib/include/pl/core/lexer.hpp
@@ -51,8 +51,14 @@ namespace pl::core {
         Token makeToken(const Token& token, size_t length = 1);
         static Token makeTokenAt(const Token& token, Location& location, size_t length = 1);
         void addToken(const Token& token);
-        size_t compareCurrentWithLongest() const {
-            return std::max(m_longestLineLength, m_cursor - m_lineBegin);
+        bool hasTheLineEnded(const char &ch) {
+            if(ch == '\n') {
+                m_longestLineLength = std::max(m_longestLineLength, m_cursor - m_lineBegin);
+                m_line++;
+                m_lineBegin = m_cursor;
+                return true;
+            }
+            return false;
         }
         std::string m_sourceCode;
         const api::Source* m_source = nullptr;

--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -134,6 +134,7 @@ namespace pl::core {
 
         void registerDirectiveHandler(const Token::Directive &name, auto memberFunction);
         void registerStatementHandler(const Token::Keyword &name, auto memberFunction);
+        void reportError(const std::string &message, const std::string &description);
 
         std::unordered_map<std::string, api::PragmaHandler> m_pragmaHandlers;
         std::unordered_map<Token::Directive, api::DirectiveHandler> m_directiveHandlers;

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -134,12 +134,8 @@ namespace pl::core {
             result += character.value();
         }
 
-        if (m_sourceCode[m_cursor] == '\n') {
-            m_longestLineLength = compareCurrentWithLongest();
-            m_line++;
-            m_lineBegin = m_cursor;
+        if (hasTheLineEnded(m_sourceCode[m_cursor]))
             m_cursor++;
-        }
 
         return makeTokenAt(Literal::makeString(result), location, result.size());
     }
@@ -160,12 +156,8 @@ namespace pl::core {
             result += character.value();
         }
 
-        if (m_sourceCode[m_cursor] == '\n') {
-            m_longestLineLength = compareCurrentWithLongest();
-            m_line++;
-            m_lineBegin = m_cursor;
+        if (hasTheLineEnded(m_sourceCode[m_cursor]))
             m_cursor++;
-        }
 
         return makeTokenAt(Literal::makeString(result), location, result.size());
     }
@@ -325,12 +317,8 @@ namespace pl::core {
         }
         auto len = m_cursor - begin;
 
-        if (m_sourceCode[m_cursor] == '\n') {
-            m_longestLineLength = compareCurrentWithLongest();
-            m_line++;
-            m_lineBegin = m_cursor;
+        if (hasTheLineEnded(m_sourceCode[m_cursor]))
             m_cursor++;
-        }
 
         return makeTokenAt(Literal::makeComment(true, result), location, len);
     }
@@ -347,12 +335,8 @@ namespace pl::core {
         }
         auto len = m_cursor - begin;
 
-        if (m_sourceCode[m_cursor] == '\n') {
-            m_longestLineLength = compareCurrentWithLongest();
-            m_line++;
-            m_lineBegin = m_cursor;
+        if (hasTheLineEnded(m_sourceCode[m_cursor]))
             m_cursor++;
-        }
 
         return makeTokenAt(Literal::makeDocComment(false, true, result), location, len);
     }
@@ -365,11 +349,7 @@ namespace pl::core {
 
         m_cursor += 3;
         while(true) {
-            if(peek(0) == '\n') {
-                m_longestLineLength = compareCurrentWithLongest();
-                m_line++;
-                m_lineBegin = m_cursor;
-            }
+            hasTheLineEnded(peek(0));
 
             if(peek(1) == '\x00') {
                 m_errorLength = 1;
@@ -395,11 +375,7 @@ namespace pl::core {
 
         m_cursor += 2;
         while(true) {
-            if(peek(0) == '\n') {
-                m_longestLineLength = compareCurrentWithLongest();
-                m_line++;
-                m_lineBegin = m_cursor;
-            }
+            hasTheLineEnded(peek(0));
 
             if(peek(1) == '\x00') {
                 m_errorLength = 2;
@@ -510,16 +486,12 @@ namespace pl::core {
             const char& c = this->m_sourceCode[this->m_cursor];
 
             if (c == '\x00') {
-                m_longestLineLength = compareCurrentWithLongest();
+                m_longestLineLength = std::max(m_longestLineLength, m_cursor - m_lineBegin);
                 break; // end of string
             }
 
             if (std::isblank(c) || std::isspace(c)) {
-                if(c == '\n') {
-                    m_line++;
-                    m_longestLineLength = compareCurrentWithLongest();
-                    m_lineBegin = m_cursor;
-                }
+                hasTheLineEnded(c);
                 m_cursor++;
                 continue;
             }
@@ -621,10 +593,7 @@ namespace pl::core {
                          peek(0) == 0  || directive == Token::Directive::IfDef  || directive == Token::Directive::IfNDef ||
                          directive == Token::Directive::EndIf)
                         continue;
-                    if (peek(0) == '\n') {
-                        m_longestLineLength = compareCurrentWithLongest();
-                        m_line++;
-                        m_lineBegin = m_cursor;
+                    if (hasTheLineEnded(peek(0))) {
                         m_cursor++;
                         continue;
                     }
@@ -633,10 +602,7 @@ namespace pl::core {
                         addToken(directiveValue.value());
                         if (m_line != line || peek(0) == 0)
                             continue;
-                        if (peek(0) == '\n') {
-                            m_longestLineLength = compareCurrentWithLongest();
-                            m_line++;
-                            m_lineBegin = m_cursor;
+                        if (hasTheLineEnded(peek(0))) {
                             m_cursor++;
                             continue;
                         }

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -135,6 +135,7 @@ namespace pl::core {
         }
 
         if (m_sourceCode[m_cursor] == '\n') {
+            m_longestLineLength = compareCurrentWithLongest();
             m_line++;
             m_lineBegin = m_cursor;
             m_cursor++;
@@ -160,6 +161,7 @@ namespace pl::core {
         }
 
         if (m_sourceCode[m_cursor] == '\n') {
+            m_longestLineLength = compareCurrentWithLongest();
             m_line++;
             m_lineBegin = m_cursor;
             m_cursor++;
@@ -324,6 +326,7 @@ namespace pl::core {
         auto len = m_cursor - begin;
 
         if (m_sourceCode[m_cursor] == '\n') {
+            m_longestLineLength = compareCurrentWithLongest();
             m_line++;
             m_lineBegin = m_cursor;
             m_cursor++;
@@ -345,6 +348,7 @@ namespace pl::core {
         auto len = m_cursor - begin;
 
         if (m_sourceCode[m_cursor] == '\n') {
+            m_longestLineLength = compareCurrentWithLongest();
             m_line++;
             m_lineBegin = m_cursor;
             m_cursor++;
@@ -362,6 +366,7 @@ namespace pl::core {
         m_cursor += 3;
         while(true) {
             if(peek(0) == '\n') {
+                m_longestLineLength = compareCurrentWithLongest();
                 m_line++;
                 m_lineBegin = m_cursor;
             }
@@ -391,6 +396,7 @@ namespace pl::core {
         m_cursor += 2;
         while(true) {
             if(peek(0) == '\n') {
+                m_longestLineLength = compareCurrentWithLongest();
                 m_line++;
                 m_lineBegin = m_cursor;
             }
@@ -494,6 +500,7 @@ namespace pl::core {
         this->m_cursor = 0;
         this->m_line = 1;
         this->m_lineBegin = 0;
+        this->m_longestLineLength = 0;
 
         const size_t end = this->m_sourceCode.size();
 
@@ -502,11 +509,15 @@ namespace pl::core {
         while(this->m_cursor < end) {
             const char& c = this->m_sourceCode[this->m_cursor];
 
-            if (c == '\x00') break; // end of string
+            if (c == '\x00') {
+                m_longestLineLength = compareCurrentWithLongest();
+                break; // end of string
+            }
 
             if (std::isblank(c) || std::isspace(c)) {
                 if(c == '\n') {
                     m_line++;
+                    m_longestLineLength = compareCurrentWithLongest();
                     m_lineBegin = m_cursor;
                 }
                 m_cursor++;
@@ -611,6 +622,7 @@ namespace pl::core {
                          directive == Token::Directive::EndIf)
                         continue;
                     if (peek(0) == '\n') {
+                        m_longestLineLength = compareCurrentWithLongest();
                         m_line++;
                         m_lineBegin = m_cursor;
                         m_cursor++;
@@ -622,6 +634,7 @@ namespace pl::core {
                         if (m_line != line || peek(0) == 0)
                             continue;
                         if (peek(0) == '\n') {
+                            m_longestLineLength = compareCurrentWithLongest();
                             m_line++;
                             m_lineBegin = m_cursor;
                             m_cursor++;

--- a/lib/source/pl/core/preprocessor.cpp
+++ b/lib/source/pl/core/preprocessor.cpp
@@ -235,21 +235,25 @@ namespace pl::core {
         // get include name
         auto *tokenLiteral = std::get_if<Token::Literal>(&m_token->value);
         if (tokenLiteral == nullptr || m_token->location.line != line ||  m_token->type != Token::Type::String) {
+            m_token--;
             errorDesc("No file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
+            m_token++;
             return;
         }
         auto path = tokenLiteral->toString(false);
         if (!(path.starts_with('"') && path.ends_with('"')) && !(path.starts_with('<') && path.ends_with('>'))) {
+            m_token--;
             errorDesc("Invalid file to include given in #include directive.", "A #include directive expects a path to a file: #include \"path/to/file\" or #include <path/to/file>.");
+            m_token++;
             return;
         }
 
         path = path.substr(1, path.length() - 2);
 
-        m_token++;
 
         if(!m_resolver) {
             errorDesc("Unable to lookup results", "No include resolver was set.");
+            m_token++;
             return;
         }
 
@@ -259,8 +263,10 @@ namespace pl::core {
             for (const auto &item: error) {
                 this->error(item);
             }
+            m_token++;
             return;
         }
+        m_token++;
         // determine if we should include this file
         if (this->m_onceIncludedFiles.contains({resolved.value(),""}) ||
             this->m_onceImportedFiles.contains({resolved.value(),""}))
@@ -317,7 +323,9 @@ namespace pl::core {
             m_token++;
 
             if (auto keyword = std::get_if<Token::Keyword>(&m_token->value); keyword != nullptr && *keyword != Token::Keyword::From) {
+                m_token--;
                 error("Expected 'from' after import *.");
+                m_token++;
                 return;
             }
             saveImport.push_back(*m_token);
@@ -338,7 +346,9 @@ namespace pl::core {
                 saveImport.push_back(*m_token);
                 m_token++;
                 if (m_token->type != Token::Type::Identifier) {
+                    m_token--;
                     error("Expected identifier after '.' in import statement.");
+                    m_token++;
                     return;
                 }
                 path += "/" + std::get_if<Token::Identifier>(&m_token->value)->get();
@@ -347,7 +357,9 @@ namespace pl::core {
                 separator = std::get_if<Token::Separator>(&m_token->value);
             }
         } else {
+            m_token--;
             errorDesc("No file to import given in import statement.", "An import statement expects a path to a file: import path.to.file; or import \"path/to/file\".");
+            m_token++;
             return;
         }
         std::string alias;
@@ -355,7 +367,9 @@ namespace pl::core {
             saveImport.push_back(*m_token);
             m_token++;
             if (m_token->type != Token::Type::Identifier) {
+                m_token--;
                 error("Expected identifier after 'as' in import statement.");
+                m_token++;
                 return;
             }
             alias = std::get_if<Token::Identifier>(&m_token->value)->get();
@@ -365,22 +379,26 @@ namespace pl::core {
 
         auto *separator = std::get_if<Token::Separator>(&m_token->value);
         if (separator == nullptr || *separator != Token::Separator::Semicolon) {
+            m_token--;
             errorDesc("No semicolon found after import statement.", "An import statement expects a semicolon at the end: import path.to.file;");
+            m_token++;
             return;
         }
         saveImport.push_back(*m_token);
-        m_token++;
         if(!m_resolver) {
             errorDesc("Unable to lookup results", "No include resolver was set.");
+            m_token++;
             return;
         }
-
+        m_token++;
         auto [resolved, error] = this->m_resolver(path);
 
         if(!resolved.has_value()) {
+            m_token -= 2;
             for (const auto &item: error) {
                 this->error(item);
             }
+            m_token +=2;
             return;
         }
         // determine if we should include this file
@@ -533,11 +551,6 @@ namespace pl::core {
 
     hlp::CompileResult<std::vector<Token>> Preprocessor::preprocess(PatternLanguage* runtime, api::Source* source, bool initialRun) {
         m_source = source;
-        m_source->content = wolv::util::replaceStrings(m_source->content, "\r\n", "\n");
-        m_source->content = wolv::util::replaceStrings(m_source->content, "\r", "\n");
-        m_source->content = wolv::util::replaceStrings(m_source->content, "\t", "    ");
-        while (m_source->content.ends_with('\n'))
-            m_source->content.pop_back();
 
         m_runtime = runtime;
         m_output.clear();


### PR DESCRIPTION
The problem existed for directives and the import statement. For example omitting the file to import or include resulted in an error marker located in the next line. The problem was that the tokens were being advanced prematurely due to a previous error fix that occurred when the same file was included twice. Imports suffered the same problem cause they were added after the bug fix. A pattern that included the same file twice was run, and it produced no errors. 

Other fixes and improvements include:
1) Moved the calculation of the longest line length of pattern source code into the lexer which already reads all the lines and can obtain it with little extra code. The code to use this improvement will be added in a soon to come pr for ImHex.

 2) The preprocessor still had code to remove tabs and extra newline characters that was both incorrect and is now unnecessary since the text editor is handling that directly. To test this code import the PE pattern which uses tabs instead of spaces