### PR TITLE
Fix conditional union size

### DIFF
--- a/tests/include/test_patterns/test_pattern_unions.hpp
+++ b/tests/include/test_patterns/test_pattern_unions.hpp
@@ -34,7 +34,7 @@ namespace pl::test {
             return R"(
                 union TestUnion {
                     s32 array[2];
-                    u128 variable;
+                    if ( true ) { u128 variable; }
                 };
 
                 TestUnion testUnion @ 0x200;


### PR DESCRIPTION
Union with conditional fields reports the size without including those fields.
See imhex issue for details https://github.com/WerWolv/ImHex/issues/1504


