### PR TITLE
Fix error description vertical spacing

### DIFF
--- a/lib/source/pl/core/error.cpp
+++ b/lib/source/pl/core/error.cpp
@@ -109,7 +109,7 @@ namespace pl::core::err::impl {
         }
 
         if (!description.empty()) {
-            errorMessage += "\n\n" + description;
+            errorMessage += "\n" + description + "\n\n";
         }
 
         return errorMessage;


### PR DESCRIPTION
Makes the error description closer to the main error message than to the next error.