### PR TITLE
evaluator: support fixed_size in variable position and add tests

### DIFF
--- a/lib/source/pl/core/ast/ast_node_attribute.cpp
+++ b/lib/source/pl/core/ast/ast_node_attribute.cpp
@@ -335,7 +335,7 @@ namespace pl::core::ast {
             auto actualSize = pattern->getSize();
             if (actualSize < requestedSize) {
                 pattern->setSize(requestedSize);
-                evaluator->setReadOffset(u64(evaluator->getReadOffset() + (requestedSize - actualSize)));
+                evaluator->setReadOffset(pattern->getOffset() + requestedSize);
             }
             else if (actualSize > requestedSize)
                 err::E0004.throwError("Type size larger than expected", fmt::format("Pattern of type {} is larger than expected. Expected size {}, got {}", pattern->getTypeName(), requestedSize, actualSize), node->getLocation());
@@ -384,6 +384,8 @@ namespace pl::core::ast {
                         .bitOffset = bitfieldPattern->getBitOffset()
                     });
                 }
+            } else if (attributable->hasAttribute("fixed_size", true)) {
+                // read offset might be modified by fixed_size's padding. keep it as is.
             } else {
                 evaluator->setBitwiseReadOffset(endOffset);
             }

--- a/tests/include/test_patterns/test_pattern_attributes.hpp
+++ b/tests/include/test_patterns/test_pattern_attributes.hpp
@@ -41,14 +41,31 @@ namespace pl::test {
                     return 1337;
                 };
 
+                struct FixedSizeTest1 {
+                    u8 x;
+                } [[fixed_size(4)]];
+
+                struct FixedSizeTest2 {
+                    u32 pos = $;
+                    u32 elem [[fixed_size(7)]];
+                    std::assert($ == pos + 7, "Fixed size variable attribute padding not working");
+
+                    pos = $;
+                    FixedSizeTest1 fixedSizeTest1;
+                    std::assert($ == pos + 4, "Fixed size pattern attribute padding not working");
+                };
+
                 FormatTransformTest formatTransformTest @ 0x00;
                 SealedTest sealedTest @ 0x10;
                 HiddenTest hiddenTest @ 0x20;
                 ColorTest colorTest @ 0x30;
                 NoUniqueAddressTest noUniqueAddressTest @ 0x40;
+                FixedSizeTest1 fixedSizeTest1 @ 0x50;
+                FixedSizeTest2 fixedSizeTest2 @ 0x60;
 
                 std::assert(formatTransformTest == 1337, "Transform attribute not working");
                 std::assert(sizeof(noUniqueAddressTest) == sizeof(u32), "No Unique Address attribute not working");
+                std::assert(sizeof(fixedSizeTest1) == 4, "Fixed size attribute not working");
             )test";
         }
 


### PR DESCRIPTION
Hi,

I tried using `Field field [[fixed_size(..)]];` and got unexpected results with the next field's position.
It seems like this use-case was never handled as the position is reset in `applyVariableAttributes`'s scope guard after being updated in `applyTypeAttributes`.

I've added a test with how I expected it to work. Let me know if that's reasonable :)

Thanks!