### PR TITLE
fix: multiline comments and max line length.

### DIFF
--- a/lib/include/pl/core/lexer.hpp
+++ b/lib/include/pl/core/lexer.hpp
@@ -49,7 +49,7 @@ namespace pl::core {
         std::optional<u128> parseInteger(std::string_view literal);
 
         Token makeToken(const Token& token, size_t length = 1);
-        Token makeTokenAt(const Token& token, Location& location, size_t length = 1);
+        static Token makeTokenAt(const Token& token, Location& location, size_t length = 1);
         void addToken(const Token& token);
         bool hasTheLineEnded(const char &ch) {
             if(ch == '\n') {

--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -458,13 +458,11 @@ namespace pl::core {
     Token Lexer::makeToken(const Token &token, const size_t length) {
         auto location = this->location();
         location.length = length;
-        m_longestLineLength = std::max(m_longestLineLength, location.column + location.length);
         return { token.type, token.value, location };
     }
 
     Token Lexer::makeTokenAt(const Token &token, Location& location, const size_t length) {
         location.length = length;
-        m_longestLineLength = std::max(m_longestLineLength, location.column + location.length);
         return { token.type, token.value, location };
     }
 


### PR DESCRIPTION
Multiline comments were being counted as one line when calculating maximum line length.