### PR TITLE
Fix strict weak ordering

### DIFF
--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -112,6 +112,9 @@ namespace pl::core {
 
     std::strong_ordering Token::Literal::operator<=>(const Literal &other) const {
         return std::visit(wolv::util::overloaded {
+            [](std::shared_ptr<ptrn::Pattern> lhs, std::shared_ptr<ptrn::Pattern> rhs) {
+                return lhs->getOffset() <=> rhs->getOffset();
+            },
             []<typename T>(T lhs, T rhs) -> std::strong_ordering {
                 if (lhs == rhs) return std::strong_ordering::equal;
                 if (lhs < rhs) return std::strong_ordering::less;
@@ -158,7 +161,7 @@ namespace pl::core {
                 }
             },
             [](auto, auto) -> std::strong_ordering {
-                return std::strong_ordering::less;
+                return std::strong_ordering::equal;
             }
         }, *this, other);
     }


### PR DESCRIPTION
This is a fix for the ImHex bug "ImHex crashes when analysing any PE file #2221".  The fix requires changes to the Pattern Language and the ImHex UI. Revision would be wise. We want to avoid collateral damage. It's a big code base and I'm new to it and the compilers/build-systems used. And the bug is complex and low-level. I suspect this will fix other random crashes. The problem is caused by two issues:
 - The std::sort algorithm conjuring up garbage due to the sorting criteria not being a strict weak ordering. See  [this](https://github.com/Voultapher/sort-research-rs/blob/main/writeup/sort_safety/text.md) link. 
 - We sort shared_ptr&lt;ptrn::Pattern&gt; by pointer value, and the object is a clone.  In essence we're changing the values as we're sorting.