### PR TITLE
Cast to int format error (Format function no longer accepts enums)

### DIFF
--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -699,7 +699,6 @@ namespace pl::ptrn {
                   m_refPattern(other.m_refPattern) {}
 
             std::unique_ptr<Pattern> clone() const override {
-                //return std::make_unique<PatternRefImpl>(*this);
                 return std::make_unique<T>(*m_refPattern);
             }
 


### PR DESCRIPTION
This is a "fix" for this [issue](https://github.com/WerWolv/ImHex/issues/2266) (Format function no longer accepts enums). I use quotes because I don't have a deep understanding of how this stuff works. This is the smallest change to PatternRef I've come up with that fixes the issue. Hope it helps.