### PR TITLE
Cast to int format error v2

### DIFF
--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -699,7 +699,8 @@ namespace pl::ptrn {
                   m_refPattern(other.m_refPattern) {}
 
             std::unique_ptr<Pattern> clone() const override {
-                return std::make_unique<PatternRefImpl>(*this);
+                //return std::make_unique<PatternRefImpl>(*this);
+                return std::make_unique<T>(*m_refPattern);
             }
 
             void accept(PatternVisitor &v) override {

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -699,7 +699,6 @@ namespace pl::ptrn {
                   m_refPattern(other.m_refPattern) {}
 
             std::unique_ptr<Pattern> clone() const override {
-                //return std::make_unique<PatternRefImpl>(*this);
                 return std::make_unique<T>(*m_refPattern);
             }
 

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -61,6 +61,11 @@ namespace pl::ptrn {
         friend class core::Evaluator;
     };
 
+    inline std::shared_ptr<Pattern> make_shared_pattern_raw(Pattern  *p)
+    {
+        return std::shared_ptr<Pattern>(p, [](Pattern*){});
+    }
+
     class Pattern {
     public:
         constexpr static u64 MainSectionId          = 0x0000'0000'0000'0000;
@@ -699,7 +704,7 @@ namespace pl::ptrn {
                   m_refPattern(other.m_refPattern) {}
 
             std::unique_ptr<Pattern> clone() const override {
-                return std::make_unique<T>(*m_refPattern);
+                return std::make_unique<PatternRefImpl>(*this);
             }
 
             void accept(PatternVisitor &v) override {

--- a/lib/include/pl/patterns/pattern_array_dynamic.hpp
+++ b/lib/include/pl/patterns/pattern_array_dynamic.hpp
@@ -173,7 +173,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this), true).value_or(result);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override {
@@ -208,7 +208,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("[ ... ]");
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this)).value_or("[ ... ]");
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_array_static.hpp
+++ b/lib/include/pl/patterns/pattern_array_static.hpp
@@ -191,7 +191,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("[ ... ]");
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this)).value_or("[ ... ]");
         }
 
         [[nodiscard]] std::string toString() override {
@@ -220,7 +220,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this), true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -455,7 +455,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this), true).value_or(result);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override {
@@ -495,7 +495,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("[ ... ]");
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this)).value_or("[ ... ]");
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -691,7 +691,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this), true).value_or(result);
         }
 
         std::string formatDisplayValue() override {
@@ -725,9 +725,9 @@ namespace pl::ptrn {
             }
 
             if (valueString.size() > 64)
-                return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or(fmt::format("{{ ... }}", valueString));
+                return Pattern::callUserFormatFunc(make_shared_pattern_raw(this)).value_or(fmt::format("{{ ... }}", valueString));
             else
-                return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or(fmt::format("{{ {} }}", valueString));
+                return Pattern::callUserFormatFunc(make_shared_pattern_raw(this)).value_or(fmt::format("{{ {} }}", valueString));
         }
 
         void setEndian(std::endian endian) override {

--- a/lib/include/pl/patterns/pattern_enum.hpp
+++ b/lib/include/pl/patterns/pattern_enum.hpp
@@ -86,7 +86,7 @@ namespace pl::ptrn {
 
         [[nodiscard]] std::string toString() override {
             u128 value = this->getValue().toUnsigned();
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(getEnumName(this->getTypeName(), value, m_enumValues));
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this), true).value_or(getEnumName(this->getTypeName(), value, m_enumValues));
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_pointer.hpp
+++ b/lib/include/pl/patterns/pattern_pointer.hpp
@@ -155,7 +155,7 @@ namespace pl::ptrn {
         [[nodiscard]] std::string toString() override {
             auto result = this->m_pointedAt->toString();
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this), true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -153,7 +153,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this), true).value_or(result);
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -199,7 +199,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("{ ... }");
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this)).value_or("{ ... }");
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_union.hpp
+++ b/lib/include/pl/patterns/pattern_union.hpp
@@ -152,7 +152,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this), true).value_or(result);
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -198,7 +198,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("{ ... }");
+            return Pattern::callUserFormatFunc(make_shared_pattern_raw(this)).value_or("{ ... }");
         }
 
         std::vector<u8> getRawBytes() override {


### PR DESCRIPTION
Another attempt at a fix for  [Cast to int format error (Format function no longer accepts enums) #166 ](https://github.com/WerWolv/PatternLanguage/pull/166)

Took me a few goes to get this. I the end it was pretty simple.

The usual disclaimers. I don't know the code base well etc.