### PR TITLE
fix: if the longest line is the last one with no terminating zero then lexer failed to account for it.

### DIFF
--- a/lib/source/pl/core/lexer.cpp
+++ b/lib/source/pl/core/lexer.cpp
@@ -651,7 +651,7 @@ namespace pl::core {
 
             m_cursor++;
         }
-
+        m_longestLineLength = std::max(m_longestLineLength, m_cursor - m_lineBegin);
         addToken(makeToken(Separator::EndOfProgram, 0));
 
         return { m_tokens, collectErrors() };


### PR DESCRIPTION
When end of file is reached measure the length of the last line before exiting.