### PR TITLE
cast-to-int-format-error-v3

### DIFF
--- a/lib/include/pl/patterns/pattern_array_dynamic.hpp
+++ b/lib/include/pl/patterns/pattern_array_dynamic.hpp
@@ -173,7 +173,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(get_shared(), true).value_or(result);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override {
@@ -208,7 +208,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("[ ... ]");
+            return Pattern::callUserFormatFunc(get_shared()).value_or("[ ... ]");
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_array_static.hpp
+++ b/lib/include/pl/patterns/pattern_array_static.hpp
@@ -191,7 +191,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("[ ... ]");
+            return Pattern::callUserFormatFunc(get_shared()).value_or("[ ... ]");
         }
 
         [[nodiscard]] std::string toString() override {
@@ -220,7 +220,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(get_shared(), true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -455,7 +455,7 @@ namespace pl::ptrn {
 
             result += " ]";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(get_shared(), true).value_or(result);
         }
 
         [[nodiscard]] bool operator==(const Pattern &other) const override {
@@ -495,7 +495,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("[ ... ]");
+            return Pattern::callUserFormatFunc(get_shared()).value_or("[ ... ]");
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -691,7 +691,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(get_shared(), true).value_or(result);
         }
 
         std::string formatDisplayValue() override {
@@ -725,9 +725,9 @@ namespace pl::ptrn {
             }
 
             if (valueString.size() > 64)
-                return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or(fmt::format("{{ ... }}", valueString));
+                return Pattern::callUserFormatFunc(get_shared()).value_or(fmt::format("{{ ... }}", valueString));
             else
-                return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or(fmt::format("{{ {} }}", valueString));
+                return Pattern::callUserFormatFunc(get_shared()).value_or(fmt::format("{{ {} }}", valueString));
         }
 
         void setEndian(std::endian endian) override {

--- a/lib/include/pl/patterns/pattern_enum.hpp
+++ b/lib/include/pl/patterns/pattern_enum.hpp
@@ -86,7 +86,7 @@ namespace pl::ptrn {
 
         [[nodiscard]] std::string toString() override {
             u128 value = this->getValue().toUnsigned();
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(getEnumName(this->getTypeName(), value, m_enumValues));
+            return Pattern::callUserFormatFunc(get_shared(), true).value_or(getEnumName(this->getTypeName(), value, m_enumValues));
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_pointer.hpp
+++ b/lib/include/pl/patterns/pattern_pointer.hpp
@@ -155,7 +155,7 @@ namespace pl::ptrn {
         [[nodiscard]] std::string toString() override {
             auto result = this->m_pointedAt->toString();
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(get_shared(), true).value_or(result);
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -153,7 +153,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(get_shared(), true).value_or(result);
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -199,7 +199,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("{ ... }");
+            return Pattern::callUserFormatFunc(get_shared()).value_or("{ ... }");
         }
 
         std::vector<u8> getRawBytes() override {

--- a/lib/include/pl/patterns/pattern_union.hpp
+++ b/lib/include/pl/patterns/pattern_union.hpp
@@ -152,7 +152,7 @@ namespace pl::ptrn {
 
             result += " }";
 
-            return Pattern::callUserFormatFunc(PatternRef::create(this), true).value_or(result);
+            return Pattern::callUserFormatFunc(get_shared(), true).value_or(result);
         }
 
         void sort(const std::function<bool (const Pattern *, const Pattern *)> &comparator) override {
@@ -198,7 +198,7 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            return Pattern::callUserFormatFunc(PatternRef::create(this)).value_or("{ ... }");
+            return Pattern::callUserFormatFunc(get_shared()).value_or("{ ... }");
         }
 
         std::vector<u8> getRawBytes() override {


### PR DESCRIPTION
Another attempt at a fix for  [Cast to int format error (Format function no longer accepts enums) #166 ](https://github.com/WerWolv/PatternLanguage/pull/166)

The previous attempt is [here](https://github.com/WerWolv/PatternLanguage/pull/167).

Both methods work, but this one is more in the spirit of how `shared_ptr`s are intended to be used and smells less of hack.

This one uses [enable_shared_from_this](https://en.cppreference.com/w/cpp/memory/enable_shared_from_this).