### PR TITLE
fix: fixes for various errors related to shared_from_this.

### DIFF
--- a/lib/include/pl/api.hpp
+++ b/lib/include/pl/api.hpp
@@ -126,7 +126,7 @@ namespace pl::api {
     /**
      * @brief A function callback called when a custom built-in type is being instantiated
      */
-    using TypeCallback = std::function<std::unique_ptr<ptrn::Pattern>(core::Evaluator *, const std::vector<core::Token::Literal> &)>;
+    using TypeCallback = std::function<std::shared_ptr<ptrn::Pattern>(core::Evaluator *, const std::vector<core::Token::Literal> &)>;
 
     /**
      * @brief A type representing a function.

--- a/lib/include/pl/patterns/pattern_array_dynamic.hpp
+++ b/lib/include/pl/patterns/pattern_array_dynamic.hpp
@@ -8,19 +8,18 @@ namespace pl::ptrn {
                                 public IInlinable,
                                 public IIndexable {
     public:
-        PatternArrayDynamic(core::Evaluator *evaluator, u64 offset, size_t size, u32 line)
-            : Pattern(evaluator, offset, size, line) { }
+        PatternArrayDynamic(core::Evaluator *evaluator, u64 offset, size_t size, u32 line) : Pattern(evaluator, offset, size, line) { }
 
-        PatternArrayDynamic(const PatternArrayDynamic &other) : Pattern(other) {
-            std::vector<std::shared_ptr<Pattern>> entries;
-            for (const auto &entry : other.m_entries)
-                entries.push_back(entry->clone());
-
-            this->setEntries(entries);
-        }
+        PatternArrayDynamic(const PatternArrayDynamic &other) : Pattern(other) {}
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternArrayDynamic(*this));
+            auto other = std::make_shared<PatternArrayDynamic>(*this);
+            std::vector<std::shared_ptr<Pattern>> entries;
+            for (const auto &entry : this->m_entries) {
+                entries.push_back(entry->clone());
+            }
+            other->setEntries(entries);
+            return other;
         }
 
         void setColor(u32 color) override {
@@ -133,7 +132,7 @@ namespace pl::ptrn {
 
             if (!entry->hasOverriddenColor())
                 entry->setBaseColor(this->getColor());
-            entry->setParent(this);
+            entry->setParent(reference());
 
             this->m_entries.emplace_back(entry);
         }

--- a/lib/include/pl/patterns/pattern_array_static.hpp
+++ b/lib/include/pl/patterns/pattern_array_static.hpp
@@ -11,12 +11,12 @@ namespace pl::ptrn {
         PatternArrayStatic(core::Evaluator *evaluator, u64 offset, size_t size, u32 line)
             : Pattern(evaluator, offset, size, line) { }
 
-        PatternArrayStatic(const PatternArrayStatic &other) : Pattern(other) {
-            this->setEntries(other.getTemplate()->clone(), other.getEntryCount());
-        }
+        PatternArrayStatic(const PatternArrayStatic &other) : Pattern(other) {}
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternArrayStatic(*this));
+            auto other = std::make_shared<PatternArrayStatic>(*this);
+            other->setEntries(this->m_template->clone(), this->m_entryCount);
+            return other;
         }
 
         [[nodiscard]] std::shared_ptr<Pattern> getEntry(size_t index) const override {
@@ -153,7 +153,7 @@ namespace pl::ptrn {
 
         void setEntries(std::shared_ptr<Pattern> &&templatePattern, size_t count) {
             this->m_template          = std::move(templatePattern);
-            this->m_template->setParent(this);
+            this->m_template->setParent(reference());
             this->m_highlightTemplates.push_back(this->m_template->clone());
             this->m_entryCount        = count;
 

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -12,7 +12,7 @@ namespace pl::ptrn {
         [[nodiscard]] const PatternBitfieldMember& getTopmostBitfield() const {
             const PatternBitfieldMember* topBitfield = this;
             while (auto parent = topBitfield->getParent()) {
-                auto parentBitfield = dynamic_cast<const PatternBitfieldMember*>(parent);
+                auto parentBitfield = dynamic_cast<const PatternBitfieldMember*>(parent.get());
                 if (parentBitfield == nullptr)
                     break;
 
@@ -55,7 +55,8 @@ namespace pl::ptrn {
     public:
         PatternBitfieldField(core::Evaluator *evaluator, u64 offset, u8 bitOffset, u8 bitSize, u32 line, PatternBitfieldMember *parentBitfield = nullptr)
                 : PatternBitfieldMember(evaluator, offset, (bitOffset + bitSize + 7) / 8, line), m_bitOffset(bitOffset % 8), m_bitSize(bitSize) {
-            this->setParent(parentBitfield);
+            if (parentBitfield != nullptr)
+                this->setParent(parentBitfield->reference());
         }
 
         PatternBitfieldField(const PatternBitfieldField &other) : PatternBitfieldMember(other) {
@@ -65,7 +66,7 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternBitfieldField(*this));
+            return std::make_shared<PatternBitfieldField>(*this);
         }
 
         [[nodiscard]] u128 readValue() const {
@@ -162,7 +163,7 @@ namespace pl::ptrn {
         using PatternBitfieldField::PatternBitfieldField;
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternBitfieldFieldSigned(*this));
+            return std::make_shared<PatternBitfieldFieldSigned>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {
@@ -186,7 +187,7 @@ namespace pl::ptrn {
         using PatternBitfieldField::PatternBitfieldField;
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternBitfieldFieldBoolean(*this));
+            return std::make_shared<PatternBitfieldFieldBoolean>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {
@@ -245,7 +246,7 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternBitfieldFieldEnum(*this));
+            return std::make_shared<PatternBitfieldFieldEnum>(*this);
         }
 
         std::string formatDisplayValue() override {
@@ -282,7 +283,7 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternBitfieldArray(*this));
+            return std::make_shared<PatternBitfieldArray>(*this);
         }
 
         [[nodiscard]] u8 getBitOffset() const override {
@@ -422,7 +423,7 @@ namespace pl::ptrn {
                 if (!entry->hasOverriddenColor())
                     entry->setBaseColor(this->getColor());
 
-                entry->setParent(this);
+                entry->setParent(reference());
 
                 this->m_sortedEntries.push_back(entry.get());
             }
@@ -554,7 +555,7 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternBitfield(*this));
+            return std::make_shared<PatternBitfield>(*this);
         }
 
         [[nodiscard]] u8 getBitOffset() const override {
@@ -643,7 +644,7 @@ namespace pl::ptrn {
                 this->setBaseColor(this->m_fields.front()->getColor());
 
             for (const auto &field : this->m_fields) {
-                field->setParent(this);
+                field->setParent(reference());
                 this->m_sortedFields.push_back(field.get());
             }
         }

--- a/lib/include/pl/patterns/pattern_boolean.hpp
+++ b/lib/include/pl/patterns/pattern_boolean.hpp
@@ -10,7 +10,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, 1, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternBoolean(*this));
+            return std::make_shared<PatternBoolean>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/include/pl/patterns/pattern_character.hpp
+++ b/lib/include/pl/patterns/pattern_character.hpp
@@ -10,7 +10,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, 1, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::make_unique<PatternCharacter>(*this);
+            return std::make_shared<PatternCharacter>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/include/pl/patterns/pattern_enum.hpp
+++ b/lib/include/pl/patterns/pattern_enum.hpp
@@ -18,7 +18,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, size, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternEnum(*this));
+            return std::make_shared<PatternEnum>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/include/pl/patterns/pattern_error.hpp
+++ b/lib/include/pl/patterns/pattern_error.hpp
@@ -10,7 +10,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, size, line), m_errorMessage(std::move(errorMessage)) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternError(*this));
+            return std::make_shared<PatternError>(*this);
         }
 
         [[nodiscard]] std::string getFormattedName() const override {

--- a/lib/include/pl/patterns/pattern_float.hpp
+++ b/lib/include/pl/patterns/pattern_float.hpp
@@ -10,7 +10,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, size, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternFloat(*this));
+            return std::make_shared<PatternFloat>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/include/pl/patterns/pattern_padding.hpp
+++ b/lib/include/pl/patterns/pattern_padding.hpp
@@ -9,7 +9,7 @@ namespace pl::ptrn {
         PatternPadding(core::Evaluator *evaluator, u64 offset, size_t size, u32 line) : Pattern(evaluator, offset, size, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternPadding(*this));
+            return std::make_shared<PatternPadding>(*this);
         }
 
         [[nodiscard]] std::string getFormattedName() const override {

--- a/lib/include/pl/patterns/pattern_pointer.hpp
+++ b/lib/include/pl/patterns/pattern_pointer.hpp
@@ -21,7 +21,7 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternPointer(*this));
+            return std::make_shared<PatternPointer>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/include/pl/patterns/pattern_signed.hpp
+++ b/lib/include/pl/patterns/pattern_signed.hpp
@@ -10,7 +10,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, size, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternSigned(*this));
+            return std::make_shared<PatternSigned>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/include/pl/patterns/pattern_string.hpp
+++ b/lib/include/pl/patterns/pattern_string.hpp
@@ -13,7 +13,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, size, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternString(*this));
+            return std::make_shared<PatternString>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -11,18 +11,17 @@ namespace pl::ptrn {
         PatternStruct(core::Evaluator *evaluator, u64 offset, size_t size, u32 line)
             : Pattern(evaluator, offset, size, line) { }
 
-        PatternStruct(const PatternStruct &other) : Pattern(other) {
-            for (const auto &member : other.m_members) {
-                auto copy = member->clone();
-
-                copy->setParent(this);
-                this->m_sortedMembers.push_back(copy.get());
-                this->m_members.push_back(std::move(copy));
-            }
-        }
+        PatternStruct(const PatternStruct &other) : Pattern(other) {}
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternStruct(*this));
+            auto other = std::make_shared<PatternStruct>(*this);
+            for (const auto &member : this->m_members) {
+                 auto copy = member->clone();
+                copy->setParent(other->reference());
+                other->m_sortedMembers.push_back(copy.get());
+                other->m_members.push_back(std::move(copy));
+            }
+            return other;
         }
 
         [[nodiscard]] std::shared_ptr<Pattern> getEntry(size_t index) const override {
@@ -36,7 +35,7 @@ namespace pl::ptrn {
         void addEntry(const std::shared_ptr<Pattern> &entry) override {
             if (entry == nullptr) return;
 
-            entry->setParent(this);
+            entry->setParent(reference());
             this->m_sortedMembers.push_back(entry.get());
             this->m_members.push_back(entry);
         }

--- a/lib/include/pl/patterns/pattern_union.hpp
+++ b/lib/include/pl/patterns/pattern_union.hpp
@@ -11,17 +11,16 @@ namespace pl::ptrn {
         PatternUnion(core::Evaluator *evaluator, u64 offset, size_t size, u32 line)
             : Pattern(evaluator, offset, size, line) { }
 
-        PatternUnion(const PatternUnion &other) : Pattern(other) {
-            for (const auto &member : other.m_members) {
-                auto copy = member->clone();
-
-                this->m_sortedMembers.push_back(copy.get());
-                this->m_members.push_back(std::move(copy));
-            }
-        }
+        PatternUnion(const PatternUnion &other) : Pattern(other) {}
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternUnion(*this));
+            auto other = std::make_shared<PatternUnion>(*this);
+            for (const auto &member : this->m_members) {
+                auto copy = member->clone();
+                other->m_sortedMembers.push_back(copy.get());
+                other->m_members.push_back(std::move(copy));
+            }
+            return other;
         }
 
         [[nodiscard]] std::shared_ptr<Pattern> getEntry(size_t index) const override {
@@ -35,7 +34,7 @@ namespace pl::ptrn {
         void addEntry(const std::shared_ptr<Pattern> &entry) override {
             if (entry == nullptr) return;
 
-            entry->setParent(this);
+            entry->setParent(reference());
             this->m_sortedMembers.push_back(entry.get());
             this->m_members.push_back(entry);
         }

--- a/lib/include/pl/patterns/pattern_unsigned.hpp
+++ b/lib/include/pl/patterns/pattern_unsigned.hpp
@@ -10,7 +10,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, size, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternUnsigned(*this));
+            return std::make_shared<PatternUnsigned>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/include/pl/patterns/pattern_wide_character.hpp
+++ b/lib/include/pl/patterns/pattern_wide_character.hpp
@@ -12,7 +12,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, 2, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternWideCharacter(*this));
+            return std::make_shared<PatternWideCharacter>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/include/pl/patterns/pattern_wide_string.hpp
+++ b/lib/include/pl/patterns/pattern_wide_string.hpp
@@ -13,7 +13,7 @@ namespace pl::ptrn {
             : Pattern(evaluator, offset, size, line) { }
 
         [[nodiscard]] std::shared_ptr<Pattern> clone() const override {
-            return std::unique_ptr<Pattern>(new PatternWideString(*this));
+            return std::make_shared<PatternWideString>(*this);
         }
 
         [[nodiscard]] core::Token::Literal getValue() const override {

--- a/lib/source/pl/core/ast/ast_node_array_variable_decl.cpp
+++ b/lib/source/pl/core/ast/ast_node_array_variable_decl.cpp
@@ -218,13 +218,13 @@ namespace pl::core::ast {
         }
 
         if (dynamic_cast<ptrn::PatternPadding *>(templatePattern.get())) {
-            outputPattern = std::make_unique<ptrn::PatternPadding>(evaluator, startOffset, 0, getLocation().line);
+            outputPattern = std::make_shared<ptrn::PatternPadding>(evaluator, startOffset, 0, getLocation().line);
         } else if (dynamic_cast<ptrn::PatternCharacter *>(templatePattern.get())) {
-            outputPattern = std::make_unique<ptrn::PatternString>(evaluator, startOffset, 0, getLocation().line);
+            outputPattern = std::make_shared<ptrn::PatternString>(evaluator, startOffset, 0, getLocation().line);
         } else if (dynamic_cast<ptrn::PatternWideCharacter *>(templatePattern.get())) {
-            outputPattern = std::make_unique<ptrn::PatternWideString>(evaluator, startOffset, 0, getLocation().line);
+            outputPattern = std::make_shared<ptrn::PatternWideString>(evaluator, startOffset, 0, getLocation().line);
         } else {
-            auto arrayPattern = std::make_unique<ptrn::PatternArrayStatic>(evaluator, startOffset, 0, getLocation().line);
+            auto arrayPattern = std::make_shared<ptrn::PatternArrayStatic>(evaluator, startOffset, 0, getLocation().line);
             arrayPattern->setEntries(templatePattern->clone(), size_t(entryCount));
             arrayPattern->setSection(templatePattern->getSection());
             outputPattern = std::move(arrayPattern);
@@ -256,7 +256,7 @@ namespace pl::core::ast {
         };
 
         evaluator->alignToByte();
-        auto arrayPattern = std::make_unique<ptrn::PatternArrayDynamic>(evaluator, evaluator->getReadOffset(), 0, getLocation().line);
+        auto arrayPattern = std::make_shared<ptrn::PatternArrayDynamic>(evaluator, evaluator->getReadOffset(), 0, getLocation().line);
         arrayPattern->setVariableName(this->m_name);
         arrayPattern->setSection(evaluator->getSectionId());
 

--- a/lib/source/pl/core/ast/ast_node_bitfield.cpp
+++ b/lib/source/pl/core/ast/ast_node_bitfield.cpp
@@ -139,7 +139,7 @@ namespace pl::core::ast {
 
         for (auto &pattern : potentialPatterns) {
             if (auto bitfieldMember = dynamic_cast<ptrn::PatternBitfieldMember*>(pattern.get()); bitfieldMember != nullptr) {
-                bitfieldMember->setParent(bitfieldPattern.get());
+                bitfieldMember->setParent(bitfieldPattern.get()->reference());
                 if (!bitfieldMember->isPadding())
                     fields.push_back(pattern);
             } else {

--- a/lib/source/pl/core/ast/ast_node_bitfield_array_variable_decl.cpp
+++ b/lib/source/pl/core/ast/ast_node_bitfield_array_variable_decl.cpp
@@ -53,7 +53,7 @@ namespace pl::core::ast {
         };
 
         auto position = evaluator->getBitwiseReadOffset();
-        auto arrayPattern = std::make_unique<ptrn::PatternBitfieldArray>(evaluator, position.byteOffset, position.bitOffset, 0, getLocation().line);
+        auto arrayPattern = std::make_shared<ptrn::PatternBitfieldArray>(evaluator, position.byteOffset, position.bitOffset, 0, getLocation().line);
         arrayPattern->setVariableName(this->m_name);
         arrayPattern->setSection(evaluator->getSectionId());
         arrayPattern->setReversed(evaluator->isReadOrderReversed());
@@ -133,7 +133,7 @@ namespace pl::core::ast {
 
             for (auto &pattern : entries) {
                 if (auto bitfieldMember = dynamic_cast<ptrn::PatternBitfieldMember*>(pattern.get()); bitfieldMember != nullptr)
-                    bitfieldMember->setParent(arrayPattern.get());
+                    bitfieldMember->setParent(arrayPattern.get()->reference());
             }
 
             arrayPattern->setEntries(entries);

--- a/lib/source/pl/core/ast/ast_node_builtin_type.cpp
+++ b/lib/source/pl/core/ast/ast_node_builtin_type.cpp
@@ -23,23 +23,23 @@ namespace pl::core::ast {
         auto size   = Token::getTypeSize(this->m_type);
         auto offset = evaluator->getReadOffsetAndIncrement(size);
 
-        std::unique_ptr<ptrn::Pattern> pattern;
+        std::shared_ptr<ptrn::Pattern> pattern;
         if (Token::isUnsigned(this->m_type))
-            pattern = std::make_unique<ptrn::PatternUnsigned>(evaluator, offset, size, getLocation().line);
+            pattern = std::make_shared<ptrn::PatternUnsigned>(evaluator, offset, size, getLocation().line);
         else if (Token::isSigned(this->m_type))
-            pattern = std::make_unique<ptrn::PatternSigned>(evaluator, offset, size, getLocation().line);
+            pattern = std::make_shared<ptrn::PatternSigned>(evaluator, offset, size, getLocation().line);
         else if (Token::isFloatingPoint(this->m_type))
-            pattern = std::make_unique<ptrn::PatternFloat>(evaluator, offset, size, getLocation().line);
+            pattern = std::make_shared<ptrn::PatternFloat>(evaluator, offset, size, getLocation().line);
         else if (this->m_type == Token::ValueType::Boolean)
-            pattern = std::make_unique<ptrn::PatternBoolean>(evaluator, offset, getLocation().line);
+            pattern = std::make_shared<ptrn::PatternBoolean>(evaluator, offset, getLocation().line);
         else if (this->m_type == Token::ValueType::Character)
-            pattern = std::make_unique<ptrn::PatternCharacter>(evaluator, offset, getLocation().line);
+            pattern = std::make_shared<ptrn::PatternCharacter>(evaluator, offset, getLocation().line);
         else if (this->m_type == Token::ValueType::Character16)
-            pattern = std::make_unique<ptrn::PatternWideCharacter>(evaluator, offset, getLocation().line);
+            pattern = std::make_shared<ptrn::PatternWideCharacter>(evaluator, offset, getLocation().line);
         else if (this->m_type == Token::ValueType::Padding)
-            pattern = std::make_unique<ptrn::PatternPadding>(evaluator, offset, 1, getLocation().line);
+            pattern = std::make_shared<ptrn::PatternPadding>(evaluator, offset, 1, getLocation().line);
         else if (this->m_type == Token::ValueType::String)
-            pattern = std::make_unique<ptrn::PatternString>(evaluator, offset, 0, getLocation().line);
+            pattern = std::make_shared<ptrn::PatternString>(evaluator, offset, 0, getLocation().line);
         else if (this->m_type == Token::ValueType::CustomType) {
             std::vector<Token::Literal> params;
 

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -225,8 +225,8 @@ namespace pl::core {
 
         this->setBitwiseReadOffset(startOffset);
 
-        auto pattern = new ptrn::PatternArrayDynamic(this, 0, typePattern->getSize() * entryCount, 0);
-
+        //auto pattern = new ptrn::PatternArrayDynamic(this, 0, typePattern->getSize() * entryCount, 0);
+        auto pattern = std::make_shared<ptrn::PatternArrayDynamic>(this, 0, typePattern->getSize() * entryCount, 0);
         if (section == ptrn::Pattern::PatternLocalSectionId) {
             typePattern->setSection(section);
             std::vector<std::shared_ptr<ptrn::Pattern>> entries;
@@ -277,7 +277,7 @@ namespace pl::core {
             this->getConsole().log(LogConsole::Level::Debug, fmt::format("Creating local array variable '{} {}[{}]' at heap address 0x{:X}.", pattern->getTypeName(), pattern->getVariableName(), entryCount, pattern->getOffset()));
 
         pattern->setConstant(constant);
-        variables.push_back(std::unique_ptr<ptrn::Pattern>(pattern));
+        variables.push_back(pattern->clone());
     }
 
     std::optional<std::string> Evaluator::findTypeName(const ast::ASTNodeTypeDecl *type) {

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -518,11 +518,11 @@ namespace pl {
                 if (this->m_aborted)
                     return;
 
-                if (auto staticArray = dynamic_cast<ptrn::PatternArrayStatic*>(pattern.get()); staticArray != nullptr) {
+                if (auto staticArray = dynamic_pointer_cast<ptrn::PatternArrayStatic>(pattern); staticArray != nullptr) {
                     if (staticArray->getEntryCount() > 0 && staticArray->getEntry(0)->getChildren().empty()) {
                         const auto address = staticArray->getOffset();
                         const auto size = staticArray->getSize();
-                        sectionTree.insert({ address, address + size - 1 }, staticArray);
+                        sectionTree.insert({ address, address + size - 1 }, staticArray.get());
                         continue;
                     }
                 }
@@ -552,7 +552,7 @@ namespace pl {
             ptrn::Pattern* value = interval.value;
 
             auto parent = value->getParent();
-            while (parent != nullptr && dynamic_cast<const ptrn::PatternArrayStatic*>(parent->getParent()) == nullptr) {
+            while (parent != nullptr && dynamic_pointer_cast<const ptrn::PatternArrayStatic>(parent->getParent()) == nullptr) {
                 parent = parent->getParent();
             }
 


### PR DESCRIPTION
A while back there were some changes to the pattern language library that changed the way shared_pointers are created using shared_from_this(). Unfortunatelly the changes were not complete and various bugs were created among them 2234, json type not working, unable to export files, static arrays of bitfields,... The cause of the errors was that in class Pattern the member m_parent was left as a raw pointer and it needs to be handled by shared pointers. Also there were some cases in which share pointers were needed but unique pointers were used instead. Both cause crashes when shared_from_this is used on pointers that are not managed by shared_ptr. Another source of errors were infinite loops of clone and reference that caused stack overflow. The fixes include making m_parent a weak pointer, turning unique pointers into shared pointers and moving codefrom the copy constructors into clone to break the infinite loops.These changes are the bare minimum needed to bring the pattern language back to the full functionality that it had before shared_from_this was introduced or at least thats the hope.