### PR TITLE
fix: values of local variables that are children of structs, arrays, bitfields or unions are set to invalid values when the setOffset() function of the parent is called.

### DIFF
--- a/lib/include/pl/patterns/pattern_array_dynamic.hpp
+++ b/lib/include/pl/patterns/pattern_array_dynamic.hpp
@@ -51,12 +51,8 @@ namespace pl::ptrn {
 
         void setOffset(u64 offset) override {
             for (auto &entry : this->m_entries) {
-                if (entry->getSection() == this->getSection()) {
-                    if (entry->getSection() != ptrn::Pattern::PatternLocalSectionId)
-                        entry->setOffset(entry->getOffset() - this->getOffset() + offset);
-                    else
-                        entry->setOffset(offset);
-                }
+                if (entry->getSection() == this->getSection() && entry->getSection() != ptrn::Pattern::PatternLocalSectionId)
+                    entry->setOffset(entry->getOffset() - this->getOffset() + offset);
             }
 
             Pattern::setOffset(offset);

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -388,12 +388,8 @@ namespace pl::ptrn {
 
         void setOffset(u64 offset) override {
             for (auto &entry : this->m_entries) {
-                if (entry->getSection() == this->getSection()) {
-                    if (entry->getSection() != ptrn::Pattern::PatternLocalSectionId)
-                        entry->setOffset(entry->getOffset() - this->getOffset() + offset);
-                    else
-                        entry->setOffset(offset);
-                }
+                if (entry->getSection() == this->getSection() && entry->getSection() != ptrn::Pattern::PatternLocalSectionId)
+                    entry->setOffset(entry->getOffset() - this->getOffset() + offset);
             }
 
             PatternBitfieldMember::setOffset(offset);
@@ -759,12 +755,8 @@ namespace pl::ptrn {
 
         void setOffset(u64 offset) override {
             for (auto &field : this->m_fields) {
-                if (field->getSection() == this->getSection()) {
-                    if (field->getSection() != ptrn::Pattern::PatternLocalSectionId)
-                        field->setOffset(field->getOffset() - this->getOffset() + offset);
-                    else
-                        field->setOffset(offset);
-                }
+                if (field->getSection() == this->getSection() && field->getSection() != ptrn::Pattern::PatternLocalSectionId)
+                    field->setOffset(field->getOffset() - this->getOffset() + offset);
             }
 
             PatternBitfieldMember::setOffset(offset);

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -72,12 +72,8 @@ namespace pl::ptrn {
 
         void setOffset(u64 offset) override {
             for (auto &member : this->m_members) {
-                if (member->getSection() == this->getSection()) {
-                    if (member->getSection() != ptrn::Pattern::PatternLocalSectionId)
-                        member->setOffset(member->getOffset() - this->getOffset() + offset);
-                    else
-                        member->setOffset(offset);
-                }
+                if (member->getSection() == this->getSection() && member->getSection() != ptrn::Pattern::PatternLocalSectionId)
+                    member->setOffset(member->getOffset() - this->getOffset() + offset);
             }
 
             Pattern::setOffset(offset);

--- a/lib/include/pl/patterns/pattern_union.hpp
+++ b/lib/include/pl/patterns/pattern_union.hpp
@@ -71,12 +71,8 @@ namespace pl::ptrn {
 
         void setOffset(u64 offset) override {
             for (auto &member : this->m_members) {
-                if (member->getSection() == this->getSection()) {
-                    if (member->getSection() != ptrn::Pattern::PatternLocalSectionId)
-                        member->setOffset(member->getOffset() - this->getOffset() + offset);
-                    else
-                        member->setOffset(offset);
-                }
+                if (member->getSection() == this->getSection() && member->getSection() != ptrn::Pattern::PatternLocalSectionId)
+                    member->setOffset(member->getOffset() - this->getOffset() + offset);
             }
 
             Pattern::setOffset(offset);


### PR DESCRIPTION
 For example when a child of the Json built in data type is used as a reference argument to a function the values of the child and all its children become zero. 
 
 For those four pattern types `setOffset()` changes the offsets of all the children and if the children are local the offset is set to the offset of the parent pattern which leads to the incorrect values for the local variables when pattern is evaluated from then on.
 
 The fix consists on removing the code that changes the offsets of local variables in the four (five?) setOffset() functions.
