### PR TITLE
fix: unions with local variables may have incorrect size.

### DIFF
--- a/lib/source/pl/core/ast/ast_node_union.cpp
+++ b/lib/source/pl/core/ast/ast_node_union.cpp
@@ -27,7 +27,8 @@ namespace pl::core::ast {
         ON_SCOPE_EXIT {
             size_t size = 0;
             for (auto &memberPattern : memberPatterns) {
-                size = std::max(memberPattern->getSize(), size);
+                if (!memberPattern->isLocal())
+                    size = std::max(memberPattern->getSize(), size);
             }
             pattern->setSize(size);
 


### PR DESCRIPTION
If the biggest variable is local the size of the union is set to it even though local variables don't contribute to the pattern size.

The fix is to check if the variable is local before using it size in the comparison.