### PR TITLE
improv: remove tabs

### DIFF
--- a/lib/include/pl/pattern_language.hpp
+++ b/lib/include/pl/pattern_language.hpp
@@ -93,7 +93,7 @@ namespace pl {
          * @param checkResult Whether to check the result of the execution
          * @return True if the execution was successful, false otherwise. Call PatternLanguage#getCompileErrors() AND PatternLanguage#getEvalError() to get the compilation or runtime errors if false is returned
          */
-        [[nodiscard]] bool executeString(std::string code, const std::string& source = api::Source::DefaultSource, const std::map<std::string, core::Token::Literal> &envVars = {}, const std::map<std::string, core::Token::Literal> &inVariables = {}, bool checkResult = true);
+        [[nodiscard]] bool executeString(const std::string& code, const std::string& source = api::Source::DefaultSource, const std::map<std::string, core::Token::Literal> &envVars = {}, const std::map<std::string, core::Token::Literal> &inVariables = {}, bool checkResult = true);
 
         /**
          * @brief Executes a pattern language file

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -187,14 +187,12 @@ namespace pl {
         return m_currAST;
     }
 
-    bool PatternLanguage::executeString(std::string code, const std::string& source, const std::map<std::string, core::Token::Literal> &envVars, const std::map<std::string, core::Token::Literal> &inVariables, bool checkResult) {
+    bool PatternLanguage::executeString(const std::string& code, const std::string& source, const std::map<std::string, core::Token::Literal> &envVars, const std::map<std::string, core::Token::Literal> &inVariables, bool checkResult) {
 	   	const auto startTime = std::chrono::high_resolution_clock::now();
         ON_SCOPE_EXIT {
             const auto endTime = std::chrono::high_resolution_clock::now();
             this->m_runningTime = std::chrono::duration_cast<std::chrono::duration<double>>(endTime - startTime).count();
         };
-
-        code = wolv::util::preprocessText(code);
 
         const auto &evaluator = this->m_internals.evaluator;
 


### PR DESCRIPTION
These changes are part of an effort aimed at removing tabs from ImHex that started some time ago. Here text preprocessing is removed from executeString() function since it will be done when the file is being imported or pasted into the text editor. There is another PR in ImHex that will include this one.