### PR TITLE
fix: imported patterns used for inheritance were not highlighted.

### DIFF
--- a/lib/include/pl/core/preprocessor.hpp
+++ b/lib/include/pl/core/preprocessor.hpp
@@ -113,6 +113,10 @@ namespace pl::core {
         }
 
         void appendToNamespaces(std::vector<Token> tokens);
+        void saveTokens(api::Source *source, const std::vector<Token> &tokens);
+        const std::map<std::string, std::vector<Token>> &getParsedImports() const {
+            return m_parsedImports;
+        }
 
     private:
         Preprocessor(const Preprocessor &);
@@ -137,6 +141,7 @@ namespace pl::core {
         void registerStatementHandler(const Token::Keyword &name, auto memberFunction);
         void reportError(const std::string &message, const std::string &description);
 
+        std::map<std::string, std::vector<Token>> m_parsedImports;
         std::unordered_map<std::string, api::PragmaHandler> m_pragmaHandlers;
         std::unordered_map<Token::Directive, api::DirectiveHandler> m_directiveHandlers;
         std::unordered_map<Token::Keyword, api::StatementHandler> m_statementHandlers;

--- a/lib/source/pl/core/parser_manager.cpp
+++ b/lib/source/pl/core/parser_manager.cpp
@@ -55,6 +55,7 @@ namespace pl::core {
 
         auto result = parser.parse(tokens.value());
         oldPreprocessor->appendToNamespaces(tokens.value());
+        oldPreprocessor->saveTokens(source, tokens.value());
 
         if (result.hasErrs())
             return Result::err(result.errs);


### PR DESCRIPTION
The problem was that imported files didn't have token sequences to obtain the UDT variables. The fix was to create maps from the file name to the token sequence and then process each imported file to obtain all the variables needed. Function variables are skipped since they can be part of the code. There are also some minor code style corrections and a fix in the text editor where the last line of a selection was not being deleted.