### PR TITLE
Strict weak ordering revisited

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -13,6 +13,7 @@ endif ()
 
 add_library(libpl ${LIBRARY_TYPE}
         source/pl/helpers/utils.cpp
+        source/pl/helpers/sort_checks.cpp
 
         source/pl/pattern_language.cpp
 

--- a/lib/include/pl/core/token.hpp
+++ b/lib/include/pl/core/token.hpp
@@ -220,8 +220,10 @@ namespace pl::core {
             constexpr bool operator==(const Comment &) const = default;
         };
 
+        using LiteralVariantType = std::variant<char, bool, u128, i128, double, std::string, std::shared_ptr<ptrn::Pattern>>;
 
-        struct Literal : std::variant<char, bool, u128, i128, double, std::string, std::shared_ptr<ptrn::Pattern>> {
+
+        struct Literal : LiteralVariantType {
             using variant::variant;
 
             [[nodiscard]] std::shared_ptr<ptrn::Pattern> toPattern() const;

--- a/lib/include/pl/helpers/sort_checks.hpp
+++ b/lib/include/pl/helpers/sort_checks.hpp
@@ -22,7 +22,6 @@ inline bool imp(bool l, bool r) {
 
 template <typename Predicate>
 auto checked_pedicate(const Predicate pred) {
-    // IDIOT: The lambda below can't know the location in the collection!
     return [=](const auto &l, const auto &r) {
         // Irreflexivity: !(x<x)
         if (pred(l,l))

--- a/lib/include/pl/helpers/sort_checks.hpp
+++ b/lib/include/pl/helpers/sort_checks.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 void sortPredicateError(const char *pMsg);
+void transitivityError(const char *pMsg, size_t b_idx, size_t e_idx, size_t x_idx, size_t y_idx);
 
 // Logical implication
 inline bool imp(bool l, bool r) {
@@ -39,12 +40,12 @@ namespace impl {
 // b[n]<b[n+1]. We'll assume this even though with a dogy predicate
 // it may not be the case.
 template <typename Iter, typename Predicate>
-void transitivity(const Iter b, const Iter e, const Predicate pred)
+void transitivity(const Iter cb, const Iter b, const Iter e, const Predicate pred)
 {
     for (Iter l=b; l<e-2; ++l) {
         for (Iter r=l+2; r<e; ++r) {
             if (!pred(*l, *r)) {
-                sortPredicateError("Transitivity");
+                transitivityError("Transitivity", b-cb, e-cb-1, l-cb, r-cb);
                 // For all x (at index n) in [b, e-1): 
                 //  pred(b[n], b[n+1]) == true
                 // pred(*l, *r) returned false however. This is in violation
@@ -61,12 +62,12 @@ void transitivity(const Iter b, const Iter e, const Predicate pred)
 //
 // Incomparability is perhaps better undersood as equality.
 template <typename Iter, typename Predicate>
-void transitivity_of_incomparability(const Iter b, const Iter e, const Predicate pred)
+void transitivity_of_incomparability(const Iter cb, const Iter b, const Iter e, const Predicate pred)
 {
     for (Iter l=b; l<e-2; ++l) {
         for (Iter r=l+2; r<e; ++r) {
             if (!(!pred(*l, *r) && !pred(*r, *l))) {
-                sortPredicateError("Transitivity of incomparability");
+                transitivityError("Transitivity of incomparability", b-cb, e-cb-1, l-cb, r-cb);
                 // For all x (at index n) in [b, e-1): 
                 //  pred(b[n], b[n+1]) == false && pred(b[n+1], b[n]) == false
                 // (!pred(*l, *r) && !pred(*r, *l)) returned false however. This is in violation
@@ -87,12 +88,12 @@ void post_sort_check(const Iter b, const Iter e, const Predicate pred) {
         if (pred(*l, *(l+1))) {
             Iter r = l+1;
             for (; r<e-1 && pred(*r, *(r+1)); ++r) {}
-            impl::transitivity(l, r+1, pred);
+            impl::transitivity(b, l, r+1, pred);
             l = r;
         } else if (!pred(*(l+1), *l)) {
             Iter r = l+1;
             for (; r<e-1 && !pred(*(r+1), *r) && !pred(*r, *(r+1)); ++r) {}
-            impl::transitivity_of_incomparability(l, r+1, pred);
+            impl::transitivity_of_incomparability(b, l, r+1, pred);
             l = r;
         }
         else {

--- a/lib/include/pl/helpers/sort_checks.hpp
+++ b/lib/include/pl/helpers/sort_checks.hpp
@@ -11,6 +11,7 @@ inline bool imp(bool l, bool r) {
 
 template <typename Predicate>
 auto checked_pedicate(const Predicate pred) {
+    // IDIOT: The lambda below can't know the location in the collection!
     return [=](const auto &l, const auto &r) {
         // Irreflexivity: !(x<x)
         if (pred(l,l))

--- a/lib/include/pl/helpers/sort_checks.hpp
+++ b/lib/include/pl/helpers/sort_checks.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <cstddef>
 #include <algorithm>
 
+namespace  pl::hlp {
+
 void sortPredicateError(const char *pMsg);
-void transitivityError(const char *pMsg, size_t b_idx, size_t e_idx, size_t x_idx, size_t y_idx);
+void transitivityError(const char *pMsg, std::size_t b_idx, std::size_t e_idx, std::size_t x_idx, std::size_t y_idx);
 
 // Logical implication
 inline bool imp(bool l, bool r) {
@@ -116,3 +119,5 @@ void checked_stable_sort(RandomIt first, RandomIt last, Compare comp) {
     std::stable_sort(first, last, checked_pedicate(comp));
     post_sort_check(first, last, comp);
 }
+
+} // namespace pl::hlp

--- a/lib/include/pl/helpers/sort_checks.hpp
+++ b/lib/include/pl/helpers/sort_checks.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#define ENABLE_STD_SORT_CHECKS
+//#define ENABLE_STD_SORT_CHECKS
 
 #ifdef ENABLE_STD_SORT_CHECKS
 #include <cstddef>

--- a/lib/include/pl/helpers/sort_checks.hpp
+++ b/lib/include/pl/helpers/sort_checks.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-//#define ENABLE_STD_SORT_CHECKS
+#define ENABLE_STD_SORT_CHECKS
 
 #ifdef ENABLE_STD_SORT_CHECKS
 #include <cstddef>

--- a/lib/include/pl/helpers/sort_checks.hpp
+++ b/lib/include/pl/helpers/sort_checks.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <algorithm>
+
+void sortPredicateError(size_t l_idx, size_t r_idx, const char *pMsg);
+
+template <typename RandomIt>
+void genSortPredicateError(RandomIt collBegin, RandomIt l, RandomIt r, const char *pMsg)
+{
+    sortPredicateError(l-collBegin, r-collBegin, pMsg);
+}
+
+// Logical implication
+inline bool imp(bool l, bool r) {
+    return !(l && !r);
+}
+
+template <typename Predicate, typename RandomIt>
+auto checked_pedicate(RandomIt b, Predicate pred) {
+    return [=](const auto &l, const auto &r) {
+        // Irreflexivity: !(x<x)
+        if (pred(l,l))
+            genSortPredicateError(b, l, r, "Irreflexivity: pred(l,l) is false");
+        if (pred(r,r))
+            genSortPredicateError(b, l, r, "Irreflexivity: pred(r,r) is false");
+
+        // Asymmetry: if l<r not r<l
+        if (!imp(pred(l,r), !pred(r,l)))
+            genSortPredicateError(b, l, r, "Asymmetry: if pred(l,r) then !pred(r,l) is false");
+        if (!imp(pred(r,l), !pred(l,r)))
+            genSortPredicateError(b, l, r, "Asymmetry: if pred(r,l) then !pred(l,r) is false");
+
+        return pred(l, r);
+    };
+}
+
+namespace impl {
+
+// Transitivity:
+// For all x,y.z in [b, e)
+//  if pred(x,y) and pred(y,z) are true then pred(x,z) is true
+//
+// All elements in [b, e) should have already been sorted so
+// b[n]<b[n+1]. We'll assume this even though with a dogy predicate
+// it may not be the case.
+template <typename Iter, typename Predicate>
+void transitivity(const Iter b, const Iter e, const Predicate pred)
+{
+    for (Iter l=b; l<e-2; ++l) {
+        for (Iter r=l+2; r<e; ++r) {
+            if (!pred(*l, *r)) {
+                genSortPredicateError(b, l, r, "Transitivity");
+                // For all x (at index n) in [b, e-1): 
+                //  pred(b[n], b[n+1]) == true
+                // pred(*l, *r) returned false however. This is in violation
+                // of a strict weak ordering.
+            }
+        }
+    }
+}
+
+// For all x,y.z in [b, e)
+//  if !pred(x,y) && !pred(y,x) && !pred(y,z) && !pred(z,y)
+//  then
+//  !pred(x,z) && !pred(z,x)
+//
+// Incomparability is perhaps better undersood as equality.
+template <typename Iter, typename Predicate>
+void transitivity_of_incomparability(const Iter b, const Iter e, const Predicate pred)
+{
+    for (Iter l=b; l<e-2; ++l) {
+        for (Iter r=l+2; r<e; ++r) {
+            if (!(!pred(*l, *r) && !pred(*r, *l))) {
+                genSortPredicateError(b, l, r, "Transitivity of incomparability");
+                // For all x (at index n) in [b, e-1): 
+                //  pred(b[n], b[n+1]) == false && pred(b[n+1], b[n]) == false
+                // (!pred(*l, *r) && !pred(*r, *l)) returned false however. This is in violation
+                // of a strict weak ordering.
+            }
+        }
+    }
+}
+
+} // namespace impl
+
+template <typename Iter, typename Predicate>
+void post_sort_check(const Iter b, const Iter e, const Predicate pred) {
+    if (b==e)
+        return;
+
+    for (Iter l=b; l<e-1;) {
+        if (pred(*l, *(l+1))) {
+            Iter r = l+1;
+            for (; r<e-1 && pred(*r, *(r+1)); ++r) {}
+            impl::transitivity(l, r+1, pred);
+            l = r;
+        } else if (!pred(*(l+1), *l)) {
+            Iter r = l+1;
+            for (; r<e-1 && !pred(*(r+1), *r) && !pred(*r, *(r+1)); ++r) {}
+            impl::transitivity_of_incomparability(l, r+1, pred);
+            l = r;
+        }
+        else {
+            // !pred(*l, *(l+1)) && pred(*(l+1), *l)
+            // So l>=r && l>r
+            genSortPredicateError(b, l, l+1, "Not sorted"); // NOT sorted!
+            ++l;
+        }
+    }
+}
+
+template<typename RandomIt, typename Compare>
+void checked_sort(RandomIt b, RandomIt e, Compare comp) {
+    std::sort(b, e, checked_pedicate(b, comp));
+    post_sort_check(b, e, comp);
+}
+
+template<typename RandomIt, typename Compare>
+void checked_stable_sort(RandomIt b, RandomIt e, Compare comp) {
+    std::stable_sort(b, e, checked_pedicate(b, comp));
+    post_sort_check(b, e, comp);
+}

--- a/lib/include/pl/helpers/sort_checks.hpp
+++ b/lib/include/pl/helpers/sort_checks.hpp
@@ -2,33 +2,27 @@
 
 #include <algorithm>
 
-void sortPredicateError(size_t l_idx, size_t r_idx, const char *pMsg);
-
-template <typename RandomIt>
-void genSortPredicateError(RandomIt collBegin, RandomIt l, RandomIt r, const char *pMsg)
-{
-    sortPredicateError(l-collBegin, r-collBegin, pMsg);
-}
+void sortPredicateError(const char *pMsg);
 
 // Logical implication
 inline bool imp(bool l, bool r) {
     return !(l && !r);
 }
 
-template <typename Predicate, typename RandomIt>
-auto checked_pedicate(RandomIt b, Predicate pred) {
+template <typename Predicate>
+auto checked_pedicate(const Predicate pred) {
     return [=](const auto &l, const auto &r) {
         // Irreflexivity: !(x<x)
         if (pred(l,l))
-            genSortPredicateError(b, l, r, "Irreflexivity: pred(l,l) is false");
+            sortPredicateError("Irreflexivity: pred(l,l) is false");
         if (pred(r,r))
-            genSortPredicateError(b, l, r, "Irreflexivity: pred(r,r) is false");
+            sortPredicateError("Irreflexivity: pred(r,r) is false");
 
         // Asymmetry: if l<r not r<l
         if (!imp(pred(l,r), !pred(r,l)))
-            genSortPredicateError(b, l, r, "Asymmetry: if pred(l,r) then !pred(r,l) is false");
+            sortPredicateError("Asymmetry: if pred(l,r) then !pred(r,l) is false");
         if (!imp(pred(r,l), !pred(l,r)))
-            genSortPredicateError(b, l, r, "Asymmetry: if pred(r,l) then !pred(l,r) is false");
+            sortPredicateError("Asymmetry: if pred(r,l) then !pred(l,r) is false");
 
         return pred(l, r);
     };
@@ -49,7 +43,7 @@ void transitivity(const Iter b, const Iter e, const Predicate pred)
     for (Iter l=b; l<e-2; ++l) {
         for (Iter r=l+2; r<e; ++r) {
             if (!pred(*l, *r)) {
-                genSortPredicateError(b, l, r, "Transitivity");
+                sortPredicateError("Transitivity");
                 // For all x (at index n) in [b, e-1): 
                 //  pred(b[n], b[n+1]) == true
                 // pred(*l, *r) returned false however. This is in violation
@@ -71,7 +65,7 @@ void transitivity_of_incomparability(const Iter b, const Iter e, const Predicate
     for (Iter l=b; l<e-2; ++l) {
         for (Iter r=l+2; r<e; ++r) {
             if (!(!pred(*l, *r) && !pred(*r, *l))) {
-                genSortPredicateError(b, l, r, "Transitivity of incomparability");
+                sortPredicateError("Transitivity of incomparability");
                 // For all x (at index n) in [b, e-1): 
                 //  pred(b[n], b[n+1]) == false && pred(b[n+1], b[n]) == false
                 // (!pred(*l, *r) && !pred(*r, *l)) returned false however. This is in violation
@@ -103,20 +97,20 @@ void post_sort_check(const Iter b, const Iter e, const Predicate pred) {
         else {
             // !pred(*l, *(l+1)) && pred(*(l+1), *l)
             // So l>=r && l>r
-            genSortPredicateError(b, l, l+1, "Not sorted"); // NOT sorted!
+            sortPredicateError("Not sorted"); // NOT sorted!
             ++l;
         }
     }
 }
 
 template<typename RandomIt, typename Compare>
-void checked_sort(RandomIt b, RandomIt e, Compare comp) {
-    std::sort(b, e, checked_pedicate(b, comp));
-    post_sort_check(b, e, comp);
+void checked_sort(RandomIt first, RandomIt last, Compare comp) {
+    std::sort(first, last, checked_pedicate(comp));
+    post_sort_check(first, last, comp);
 }
 
 template<typename RandomIt, typename Compare>
-void checked_stable_sort(RandomIt b, RandomIt e, Compare comp) {
-    std::stable_sort(b, e, checked_pedicate(b, comp));
-    post_sort_check(b, e, comp);
+void checked_stable_sort(RandomIt first, RandomIt last, Compare comp) {
+    std::stable_sort(first, last, checked_pedicate(comp));
+    post_sort_check(first, last, comp);
 }

--- a/lib/include/pl/helpers/sort_checks.hpp
+++ b/lib/include/pl/helpers/sort_checks.hpp
@@ -1,9 +1,16 @@
 #pragma once
 
+#define ENABLE_STD_SORT_CHECKS
+
+#ifdef ENABLE_STD_SORT_CHECKS
 #include <cstddef>
+#endif
+
 #include <algorithm>
 
 namespace  pl::hlp {
+
+#ifdef ENABLE_STD_SORT_CHECKS
 
 void sortPredicateError(const char *pMsg);
 void transitivityError(const char *pMsg, std::size_t b_idx, std::size_t e_idx, std::size_t x_idx, std::size_t y_idx);
@@ -108,16 +115,26 @@ void post_sort_check(const Iter b, const Iter e, const Predicate pred) {
     }
 }
 
+#endif // ENABLE_STD_SORT_CHECKS
+
 template<typename RandomIt, typename Compare>
 void checked_sort(RandomIt first, RandomIt last, Compare comp) {
+#ifdef ENABLE_STD_SORT_CHECKS
     std::sort(first, last, checked_pedicate(comp));
     post_sort_check(first, last, comp);
+#else
+    std::sort(first, last, comp);
+#endif
 }
 
 template<typename RandomIt, typename Compare>
 void checked_stable_sort(RandomIt first, RandomIt last, Compare comp) {
+#ifdef ENABLE_STD_SORT_CHECKS
     std::stable_sort(first, last, checked_pedicate(comp));
     post_sort_check(first, last, comp);
+#else
+    std::stable_sort(first, last, comp);
+#endif
 }
 
 } // namespace pl::hlp

--- a/lib/include/pl/helpers/variant_type_index.hpp
+++ b/lib/include/pl/helpers/variant_type_index.hpp
@@ -11,15 +11,17 @@ struct variant_type_index;
 
 template<typename T, typename... Ts>
 struct variant_type_index<T, std::variant<Ts...>> {
-    static constexpr std::size_t value = []{
+    static constexpr auto value = [] -> std::size_t {
+        static_assert(
+            (std::is_same_v<std::remove_cvref_t<T>, Ts> || ...),
+            "T not in std::variant");
         constexpr bool matches[] = { std::is_same_v<std::remove_cvref_t<T>, Ts>... };
 
-        std::size_t idx = 0;
-        for (std::size_t i = 0; i < sizeof...(Ts); ++i) {
-            if (matches[i]) { idx = i; }
+        for (std::size_t i=0; i<sizeof...(Ts); ++i) {
+            if (matches[i]) { return i; }
         }
 
-        return idx;
+        return -1;
     }();
 };
 

--- a/lib/include/pl/helpers/variant_type_index.hpp
+++ b/lib/include/pl/helpers/variant_type_index.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <variant>
+#include <type_traits>
+#include <cstddef>
+
+namespace pl::hlp {
+
+template<typename T, typename Variant>
+struct variant_type_index;
+
+template<typename T, typename... Ts>
+struct variant_type_index<T, std::variant<Ts...>> {
+    static constexpr std::size_t value = []{
+        constexpr bool matches[] = { std::is_same_v<std::remove_cvref_t<T>, Ts>... };
+
+        std::size_t idx = 0;
+        for (std::size_t i = 0; i < sizeof...(Ts); ++i) {
+            if (matches[i]) { idx = i; }
+        }
+
+        return idx;
+    }();
+};
+
+template<class T, class Variant>
+inline constexpr std::size_t variant_type_index_v = variant_type_index<T, Variant>::value;
+
+} // namespace pl::hlp

--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -2,6 +2,7 @@
 
 #include <pl/patterns/pattern.hpp>
 #include <pl/patterns/pattern_enum.hpp>
+#include <pl/helpers/sort_checks.hpp>
 
 namespace pl::ptrn {
 
@@ -497,7 +498,7 @@ namespace pl::ptrn {
             for (auto &member : this->m_entries)
                 this->m_sortedEntries.push_back(member.get());
 
-            std::sort(this->m_sortedEntries.begin(), this->m_sortedEntries.end(), comparator);
+            pl::hlp::checked_sort(this->m_sortedEntries.begin(), this->m_sortedEntries.end(), comparator);
             if (this->isReversed())
                 std::reverse(this->m_sortedEntries.begin(), this->m_sortedEntries.end());
 
@@ -774,7 +775,7 @@ namespace pl::ptrn {
             for (auto &member : this->m_fields)
                 this->m_sortedFields.push_back(member.get());
 
-            std::sort(this->m_sortedFields.begin(), this->m_sortedFields.end(), comparator);
+            pl::hlp::checked_sort(this->m_sortedFields.begin(), this->m_sortedFields.end(), comparator);
             if (this->isReversed())
                 std::reverse(this->m_sortedFields.begin(), this->m_sortedFields.end());
 

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -161,23 +161,7 @@ namespace pl::ptrn {
             for (auto &member : this->m_members)
                 this->m_sortedMembers.push_back(member.get());
 
-            // DEBUGGING
-            auto smb = &m_sortedMembers[0]; (void)smb;
-            for (auto p : m_sortedMembers) {
-                auto vn = p->getVariableName();
-                int a=1;(void)a;
-            }
-            //
-
             pl::hlp::checked_sort(this->m_sortedMembers.begin(), this->m_sortedMembers.end(), comparator);
-
-            // DEBUGGING
-            std::vector<Pattern *> postSorted;
-            for (auto p : m_sortedMembers) {
-                postSorted.push_back(p);
-            }
-            //
-
             for (auto &member : this->m_sortedMembers)
                 member->sort(comparator);
         }

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -161,7 +161,22 @@ namespace pl::ptrn {
             for (auto &member : this->m_members)
                 this->m_sortedMembers.push_back(member.get());
 
+            // DEBUGGING
+            auto smb = &m_sortedMembers[0]; (void)smb;
+            for (auto p : m_sortedMembers) {
+                auto vn = p->getVariableName();
+                int a=1;(void)a;
+            }
+            //
+
             checked_sort(this->m_sortedMembers.begin(), this->m_sortedMembers.end(), comparator);
+
+            // DEBUGGING
+            std::vector<Pattern *> postSorted;
+            for (auto p : m_sortedMembers) {
+                postSorted.push_back(p);
+            }
+            //
 
             for (auto &member : this->m_sortedMembers)
                 member->sort(comparator);

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pl/patterns/pattern.hpp>
+#include <pl/helpers/sort_checks.hpp>
 
 namespace pl::ptrn {
 
@@ -160,7 +161,7 @@ namespace pl::ptrn {
             for (auto &member : this->m_members)
                 this->m_sortedMembers.push_back(member.get());
 
-            std::sort(this->m_sortedMembers.begin(), this->m_sortedMembers.end(), comparator);
+            checked_sort(this->m_sortedMembers.begin(), this->m_sortedMembers.end(), comparator);
 
             for (auto &member : this->m_sortedMembers)
                 member->sort(comparator);

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -169,7 +169,7 @@ namespace pl::ptrn {
             }
             //
 
-            checked_sort(this->m_sortedMembers.begin(), this->m_sortedMembers.end(), comparator);
+            pl::hlp::checked_sort(this->m_sortedMembers.begin(), this->m_sortedMembers.end(), comparator);
 
             // DEBUGGING
             std::vector<Pattern *> postSorted;

--- a/lib/include/pl/patterns/pattern_union.hpp
+++ b/lib/include/pl/patterns/pattern_union.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pl/patterns/pattern.hpp>
+#include <pl/helpers/sort_checks.hpp>
 
 namespace pl::ptrn {
 
@@ -159,7 +160,7 @@ namespace pl::ptrn {
             for (auto &member : this->m_members)
                 this->m_sortedMembers.push_back(member.get());
 
-            std::sort(this->m_sortedMembers.begin(), this->m_sortedMembers.end(), comparator);
+            pl::hlp::checked_sort(this->m_sortedMembers.begin(), this->m_sortedMembers.end(), comparator);
 
             for (auto &member : this->m_members)
                 member->sort(comparator);

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -162,7 +162,7 @@ namespace pl::core {
                 }
             },
             []<typename TL, typename TR>(TL, TR) -> std::strong_ordering {
-                return pl::hlp::variant_type_index_v<TL, LiteralVariantType> <=> pl::hlp::variant_type_index_v<TR, LiteralVariantType>;
+                return hlp::variant_type_index_v<TL, LiteralVariantType> <=> hlp::variant_type_index_v<TR, LiteralVariantType>;
             }
         }, *this, other);
     }

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -5,6 +5,7 @@
 
 #include <pl/helpers/utils.hpp>
 #include <pl/helpers/concepts.hpp>
+#include <pl/helpers/variant_type_index.hpp>
 #include <variant>
 
 namespace pl::core {
@@ -110,29 +111,6 @@ namespace pl::core {
         return std::holds_alternative<std::shared_ptr<ptrn::Pattern>>(*this);
     }
 
-///
-template<typename T, typename Variant>
-struct variant_index;
-
-template<typename T, typename... Ts>
-struct variant_index<T, std::variant<Ts...>> {
-    static constexpr std::size_t value = []{
-        constexpr bool matches[] = { std::is_same_v<std::remove_cvref_t<T>, Ts>... };
-
-        std::size_t idx = 0;
-        for (std::size_t i = 0; i < sizeof...(Ts); ++i) {
-            if (matches[i]) { idx = i; }
-        }
-
-        return idx;
-    }();
-};
-
-template<class T, class Variant>
-inline constexpr std::size_t variant_index_v = variant_index<T, Variant>::value;
-///
-
-
     std::strong_ordering Token::Literal::operator<=>(const Literal &other) const {
         return std::visit(wolv::util::overloaded {
             [](std::shared_ptr<ptrn::Pattern> lhs, std::shared_ptr<ptrn::Pattern> rhs) {
@@ -185,7 +163,7 @@ inline constexpr std::size_t variant_index_v = variant_index<T, Variant>::value;
             },
             []<typename TL, typename TR>(TL, TR) -> std::strong_ordering {
                 using V = std::variant<char, bool, u128, i128, double, std::string, std::shared_ptr<ptrn::Pattern>>;
-                return variant_index_v<TL, V> <=> variant_index_v<TR, V>;
+                return pl::hlp::variant_type_index_v<TL, V> <=> pl::hlp::variant_type_index_v<TR, V>;
                 //return std::strong_ordering::equal;
             }
         }, *this, other);

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -162,9 +162,7 @@ namespace pl::core {
                 }
             },
             []<typename TL, typename TR>(TL, TR) -> std::strong_ordering {
-                using V = std::variant<char, bool, u128, i128, double, std::string, std::shared_ptr<ptrn::Pattern>>;
-                return pl::hlp::variant_type_index_v<TL, V> <=> pl::hlp::variant_type_index_v<TR, V>;
-                //return std::strong_ordering::equal;
+                return pl::hlp::variant_type_index_v<TL, LiteralVariantType> <=> pl::hlp::variant_type_index_v<TR, LiteralVariantType>;
             }
         }, *this, other);
     }

--- a/lib/source/pl/core/token.cpp
+++ b/lib/source/pl/core/token.cpp
@@ -110,6 +110,29 @@ namespace pl::core {
         return std::holds_alternative<std::shared_ptr<ptrn::Pattern>>(*this);
     }
 
+///
+template<typename T, typename Variant>
+struct variant_index;
+
+template<typename T, typename... Ts>
+struct variant_index<T, std::variant<Ts...>> {
+    static constexpr std::size_t value = []{
+        constexpr bool matches[] = { std::is_same_v<std::remove_cvref_t<T>, Ts>... };
+
+        std::size_t idx = 0;
+        for (std::size_t i = 0; i < sizeof...(Ts); ++i) {
+            if (matches[i]) { idx = i; }
+        }
+
+        return idx;
+    }();
+};
+
+template<class T, class Variant>
+inline constexpr std::size_t variant_index_v = variant_index<T, Variant>::value;
+///
+
+
     std::strong_ordering Token::Literal::operator<=>(const Literal &other) const {
         return std::visit(wolv::util::overloaded {
             [](std::shared_ptr<ptrn::Pattern> lhs, std::shared_ptr<ptrn::Pattern> rhs) {
@@ -160,8 +183,10 @@ namespace pl::core {
                     return std::strong_ordering::greater;
                 }
             },
-            [](auto, auto) -> std::strong_ordering {
-                return std::strong_ordering::equal;
+            []<typename TL, typename TR>(TL, TR) -> std::strong_ordering {
+                using V = std::variant<char, bool, u128, i128, double, std::string, std::shared_ptr<ptrn::Pattern>>;
+                return variant_index_v<TL, V> <=> variant_index_v<TR, V>;
+                //return std::strong_ordering::equal;
             }
         }, *this, other);
     }

--- a/lib/source/pl/helpers/sort_checks.cpp
+++ b/lib/source/pl/helpers/sort_checks.cpp
@@ -1,6 +1,15 @@
 #include <pl/helpers/sort_checks.hpp>
 #include <iostream>
 
+using std::cout;
+using std::endl;
+
 void sortPredicateError(const char *pMsg) {
-    std::cout << pMsg << std::endl;
+    cout << pMsg << endl;
+}
+
+void transitivityError(const char *pMsg, size_t b_idx, size_t e_idx, size_t x_idx, size_t y_idx) {
+    cout << pMsg << endl
+         << "   Run: " << "b_idx=" << b_idx << ", e_idx=" << e_idx << endl
+         << "   Error: " << "x_idx=" << x_idx << ", y_idx=" << y_idx << endl;
 }

--- a/lib/source/pl/helpers/sort_checks.cpp
+++ b/lib/source/pl/helpers/sort_checks.cpp
@@ -1,4 +1,6 @@
 #include <pl/helpers/sort_checks.hpp>
+
+#ifdef ENABLE_STD_SORT_CHECKS
 #include <cstddef>
 #include <iostream>
 
@@ -19,3 +21,5 @@ void transitivityError(const char *pMsg, size_t b_idx, size_t e_idx, size_t x_id
 }
 
 } // namespace pl::hlp
+
+#endif // ENABLE_STD_SORT_CHECKS

--- a/lib/source/pl/helpers/sort_checks.cpp
+++ b/lib/source/pl/helpers/sort_checks.cpp
@@ -1,7 +1,6 @@
 #include <pl/helpers/sort_checks.hpp>
 #include <iostream>
 
-void sortPredicateError(size_t l_idx, size_t r_idx, const char *pMsg) {
-    (void)l_idx; (void)r_idx;
+void sortPredicateError(const char *pMsg) {
     std::cout << pMsg << std::endl;
 }

--- a/lib/source/pl/helpers/sort_checks.cpp
+++ b/lib/source/pl/helpers/sort_checks.cpp
@@ -1,0 +1,7 @@
+#include <pl/helpers/sort_checks.hpp>
+#include <iostream>
+
+void sortPredicateError(size_t l_idx, size_t r_idx, const char *pMsg) {
+    (void)l_idx; (void)r_idx;
+    std::cout << pMsg << std::endl;
+}

--- a/lib/source/pl/helpers/sort_checks.cpp
+++ b/lib/source/pl/helpers/sort_checks.cpp
@@ -1,8 +1,12 @@
 #include <pl/helpers/sort_checks.hpp>
+#include <cstddef>
 #include <iostream>
 
+using std::size_t;
 using std::cout;
 using std::endl;
+
+namespace pl::hlp {
 
 void sortPredicateError(const char *pMsg) {
     cout << pMsg << endl;
@@ -13,3 +17,5 @@ void transitivityError(const char *pMsg, size_t b_idx, size_t e_idx, size_t x_id
          << "   Run: " << "b_idx=" << b_idx << ", e_idx=" << e_idx << endl
          << "   Error: " << "x_idx=" << x_idx << ", y_idx=" << y_idx << endl;
 }
+
+} // namespace pl::hlp


### PR DESCRIPTION
### Overview

Some time ago I fixed a crash related to sorting in the pattern drawer. The cause was a sort predicate that did not implement strict weak ordering correctly. I have revisited this and found (and fixed) another violation (transitivity of incomparability).

The code I used to find this is included in this PR (disabled).

The issue is [here](https://github.com/WerWolv/PatternLanguage/issues/187).

A [PR](https://github.com/WerWolv/PatternLanguage/pull/188) without the sort checking code.


###  A bad sort predicate. So what?

I made this [repo](https://github.com/shewitt-au/ConjureGarbage) to demonstrate some of the potential consequences of incorrect strict weak ordering. I've made it easy. It's simple and can be built with CMake. I've mainly ran it on mingw64 (it exhibits the most severe consequences, and the ImHex I use is built with it) . It uses a deliberatly poorly coded sort predicate which attempts to simulate the bug I referred to above. It shuffles a vector; sorts it with a bad predicate; check for gargabe; repeats. Strap in and check it out. Here's an example run I'll kick off right now.

```
$ ./bin/main.exe
Reference vector:
  1   2   3   4   5   6   7   8   9  10
 11  12  13  14  15  16  17  18  19  20
 21  22  23  24  25  26  27  28  29  30
 31  32  33  34  35  36  37  38  39  40
 41  42  43  44  45  46  47  48  49  50
 51  52  53  54  55  56  57  58  59  60
 61  62  63  64  65  66  67  68  69  70
 71  72  73  74  75  76  77  78  79  80
 81  82  83  84  85  86  87  88  89  90
 91  92  93  94  95  96  97  98  99 100

Times shuffled: 15

vector before sorting:
 82  55  88  32   9  54  38  89  71  21
 87 100  27  92  28  31  83  26  13  91
  6  17   8  60  16  68  84  24  62  75
 64  96  14   1  93  58  74  51  95  29
  3  80  86  44  50  65  10  43  23  70
 25   4  40  19   2  97  36  94  41  49
 18  85  81  78  45  52  35  99  79  61
 57  73  42  98   5  56  90  69  39  72
 59  63  46  34  11  67   7  33  12  20
 47  53  37  66  77  15  48  76  30  22

vector after sorting:
  0   0   0   0   0   0 597167803 268445148   1   2
  3   4   5   6   7   8   9  10  11  12
 13  14  15  16  17  18  19  20  21  22
 23  24  25  26  27  28  29  30  31  32
 33  34  35  36  37  38  39  40  41  42
 43  44  45  46  47  48  49  50  51  52
 53  54  55  56  57  58  59  65  60  61
 62  63  64  66  67  68  69  70  71  72
 73  74  75  76  77  78  79  90  80  81
 82  83  84  85  86  87  88  89 100  95
```

### The problem

Incomparability for us just means equality. If `x<y` is `false` and `y<x` is `false` (`x` and `y` are incomparable) we say `x==y`.

In the code path were I found this issue (sorting by the "Value" column) the code in `std::strong_ordering Token::Literal::operator<=>` does the comparison. If `lhs` and `rhs` are the same type the implementation is pretty straight forward. It handles some cases where `lhs` and `rhs` and different numeric types.

Then we get this
```c++
[](auto, auto) -> std::strong_ordering {
    return std::strong_ordering::equal;
}
```
If `lhs` and `rhs` are different types we consider them equal. This is the most sensibe value we could unconditionally return, but in our case it wont do the trick.

Say we have a `u128` `x`, a `std::string` `y` and another `u128` `z`.
The code the above gives  `x==y` (different types).
Similarly `y==z`.

Transitivity of incomparability (equality) mandates that in this case `x==z`.
But `x` and `z` are the same type, `u128`. The comparison is numerical. If `x` and `z` have different values then `x==z` is **NOT** `true` as is required. We have violated the strict weak ordering.

### The solution in the PR

I have altered the code quoted above to look like this:
```c++
 []<typename TL, typename TR>(TL, TR) -> std::strong_ordering {
     return hlp::variant_type_index_v<TL, LiteralVariantType> <=> hlp::variant_type_index_v<TR, LiteralVariantType>;
    }
```
`hlp::variant_type_index_v` is a utility I wrote the get the index of a type in a `std::variant`. 

The `std::variant` we use looks like this:
```c++
std::variant<char, bool, u128, i128, double, std::string, std::shared_ptr<ptrn::Pattern>>;
```

So `char` < `bool`, `bool` < `std::shared_ptr<ptrn::Pattern>` etc... The comparison is based on the type index in the `std::variant`.

In the example I gave above now `x<y` and `y>z`, so transitivity does not apply.

### Conslusion

A sort predicate that does not implement a strict weak ordering correctly is dangerous. Elements can be deleted. Element that never existed in the sequence to be sorted are sometimes conjured. In the example program I linked above I get heap corruption. MingW64 seems particularly vulnarable. I'm judging here. Perhaps when the predicate is well formed this is a strength. It's not a strenght when it's malformed however.