### PR TITLE
Update pattern_language_git_hash to use github.ref instead of github.sha in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,4 +89,4 @@ jobs:
     uses: WerWolv/ImHex-Patterns/.github/workflows/tests.yml@master
     with:
       pattern_language_git_repo: ${{ github.server_url }}/${{ github.repository }}
-      pattern_language_git_hash: ${{ github.sha }}
+      pattern_language_git_hash: ${{ github.ref }}


### PR DESCRIPTION
github.sha does not work for pull requests.