### PR TITLE
Early termination of formatDisplayValue for bitfield

### DIFF
--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -713,7 +713,7 @@ namespace pl::ptrn {
                     valueString += fmt::format("{} = {} | ", bitfield->getVariableName(), bitfield->formatDisplayValue());
                 }
 
-                if(valueString.size() - 3 > 64) {
+                if (valueString.size() - 3 > 64) {
                     break;
                 }
             }


### PR DESCRIPTION
When you have a rather large recursively defined bitfield, the UI can hang for a while. This commit makes it stop early when the string reaches 64 characters.