### PR TITLE
evaulator: fix crash on identity using declarations

### DIFF
--- a/lib/source/pl/core/ast/ast_node_type_application.cpp
+++ b/lib/source/pl/core/ast/ast_node_type_application.cpp
@@ -127,9 +127,20 @@ namespace pl::core::ast {
 
         ast::ASTNode* type = this->getType().get();
         if (auto typDecl = dynamic_cast<ast::ASTNodeTypeDecl*>(type); typDecl != nullptr) {
+            std::vector<std::unique_ptr<ASTNode>> templateArgs(this->m_templateArguments.size());
+            for (size_t i = 0; i < this->m_templateArguments.size(); i++) {
+                auto &templateArgument = this->m_templateArguments[i];
+                if (auto typeApp = dynamic_cast<ast::ASTNodeTypeApplication*>(templateArgument.get()); typeApp != nullptr) {
+                    templateArgs[i] = templateArgument->evaluate(evaluator);
+                }
+            }
+
+            evaluator->setCurrentTemplateArguments(std::move(templateArgs));
             return typDecl->getTypeDefinition(evaluator);
         } else if(auto builtinType = dynamic_cast<ast::ASTNodeBuiltinType*>(type); builtinType != nullptr) {
             return builtinType;
+        } else if(auto typeApp = dynamic_cast<ast::ASTNodeTypeApplication*>(type); typeApp != nullptr) {
+            return typeApp->getTypeDefinition(evaluator);
         }
     
         return nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(AVAILABLE_TESTS
         TemplateParametersScope
         TypeNameOf
         CustomBuiltInType
+        Using
 )
 
 

--- a/tests/include/test_patterns/test_pattern_using.hpp
+++ b/tests/include/test_patterns/test_pattern_using.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "test_pattern.hpp"
+
+namespace pl::test {
+
+    class TestPatternUsing : public TestPattern {
+    public:
+        TestPatternUsing(core::Evaluator *evaluator) : TestPattern(evaluator, "Using") {
+        }
+        ~TestPatternUsing() override = default;
+
+        [[nodiscard]] std::string getSourceCode() const override {
+            return R"(
+                using US<T> = T;
+                US<u32> u;
+                US<u32> v = 64;
+                u = 64;
+                std::assert(u == 64 && v == 64, "u,v should be 64");
+
+                using UST<T> = US<T>;
+                UST<u32> ust;
+                UST<u32> vst = 16;
+                ust = 16;
+                std::assert(ust == 16 && vst == 16, "ust,vst should be 16");
+
+                struct USS<T> {
+                    US<T> us = 16;
+                };
+                USS<u32> uss;
+                std::assert(uss.us == 16, "us should be 16");
+
+                USS<US<u32>> ussus;
+                std::assert(ussus.us == 16, "ussus should be 16");
+
+                US<u8> us2[2];
+                US<u8> us3[2] @ 0;
+                std::assert(us3[0] == 137, "us3[0] should be 137");
+
+                namespace A {
+                    using US<T> = T;
+                }
+                A::US<u8> us4;
+                A::US<u8> us5 @ 0;
+                us4 = us5;
+                std::assert(us5 == 137 && us4 == 137, "us4, us5 should be 137");
+            )";
+        }
+    };
+
+}

--- a/tests/source/tests.cpp
+++ b/tests/source/tests.cpp
@@ -30,6 +30,7 @@
 #include "test_patterns/test_pattern_template_parameters_scope.hpp"
 #include "test_patterns/test_pattern_typenameof.hpp"
 #include "test_patterns/test_pattern_custom_builtin_type.hpp"
+#include "test_patterns/test_pattern_using.hpp"
 
 static pl::core::Evaluator s_evaluator;
 
@@ -65,4 +66,5 @@ std::array Tests = {
     TEST(TemplateParametersScope),
     TEST(TypeNameOf),
     TEST(CustomBuiltinType),
+    TEST(Using),
 };


### PR DESCRIPTION
This commit resolves a crash that occurred when processing using declarations that aliased a type to its template parameter, such as using T<K> = K. This was caused by a type not being resolved in getTypeDefinition. 

The fix ensures that type template arguments are passed down in getTypeDefinition, and extracts the actual type definition.