### PR TITLE
evaluator: Optimize call stack recording

### DIFF
--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -100,6 +100,8 @@ namespace pl::core {
             ~UpdateHandler();
 
             Evaluator *evaluator;
+            const ast::ASTNode *node = nullptr;
+            u64 offset = 0;
         };
 
         struct StackTrace {

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -1155,7 +1155,8 @@ namespace pl::core {
                         evaluator->m_lastPauseLine = std::nullopt;
                 }
             }
-            evaluator->m_callStack.emplace_back(node->clone(), evaluator->getReadOffset());
+            this->node = node;
+            this->offset = evaluator->getReadOffset();
         }
     }
 
@@ -1163,12 +1164,9 @@ namespace pl::core {
         if (evaluator->m_evaluated)
             return;
 
-        // Don't pop scopes if an exception is currently being thrown so we can generate
-        // a stack trace
-        if (std::uncaught_exceptions() > 0)
-            return;
-
-        evaluator->m_callStack.pop_back();
+        if (std::uncaught_exceptions() > 0) [[unlikely]]
+            if (node != nullptr)
+                evaluator->m_callStack.emplace_back(node->clone(), offset);
     }
 
     Evaluator::UpdateHandler Evaluator::updateRuntime(const ast::ASTNode *node) {

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -267,7 +267,7 @@ namespace pl {
 
             const auto &callStack = evaluator->getCallStack();
             u32 lastLine = 0;
-            for (const auto &entry : callStack | std::views::reverse) {
+            for (const auto &entry : callStack) {
                 const auto &[node, address] = entry;
                 if (node == nullptr)
                     continue;


### PR DESCRIPTION
Moved call stack entry recording to stack unwinding phase when exception is active. 
Eliminates overhead in normal execution.