### PR TITLE
Change to make the upcoming pt in imhex repo compile without errors.

### DIFF
--- a/lib/include/pl/core/errors/error.hpp
+++ b/lib/include/pl/core/errors/error.hpp
@@ -108,6 +108,7 @@ namespace pl::core::err {
     class CompileError {
 
     public:
+        CompileError() = default;
         CompileError(std::string message, const Location& location) : m_message(std::move(message)), m_location(location) { }
         CompileError(std::string message, std::string description, const Location& location) : m_message(std::move(message)), m_description(std::move(description)),
                                                                                               m_location(location) { }


### PR DESCRIPTION
The new changes made there cause a mussing constructor error on the errors class because it is missing a default constructor or at least the error goes away when the default constructor is added. If there is a better way to handle this let me know.