### PR TITLE
fix: improved error messages

### DIFF
--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -970,6 +970,9 @@ namespace pl::core {
             statement = parseFunctionVariableDecl();
         } else if (sequence(tkn::Keyword::Const)) {
             statement = parseFunctionVariableDecl(true);
+        } else if (m_curr[0].type == Token::Type::Keyword) {
+            errorHere("Invalid {} found in function.", getFormattedToken(0));
+            return nullptr;
         } else {
             errorHere("Invalid function statement.");
             next();
@@ -1930,7 +1933,10 @@ namespace pl::core {
             return parseTryCatchStatement([this] { return parseMember(); });
         else if (oneOf(tkn::Keyword::Return, tkn::Keyword::Break, tkn::Keyword::Continue))
             member = parseFunctionControlFlowStatement();
-        else {
+        else if (m_curr[0].type == Token::Type::Keyword) {
+            errorHere("Invalid {} found in struct.", getFormattedToken(0));
+            return nullptr;
+        } else {
             errorHere("Invalid struct member definition.");
             next();
             return nullptr;


### PR DESCRIPTION
Currently, when the parser encounters an invalid keyword inside a function or a structure it gives an invalid function statement or invalid member definition error instead of stating that an invalid keyword was found. 

This PR aims at detecting any keyword that is caught after all the valid ones have been parsed to give a more appropriate error message 

This was written as a response to the feature request of better error messages when loops are used inside structs made in the ImHex issues #2687 but expands on it to include all possible invalid keywords.