### PR TITLE
fix: base address dependant storage

### DIFF
--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -708,17 +708,13 @@ namespace pl::core {
                     }
 
                     auto &storage = getStorage();
-                    auto section = value->getSection();
-                    if (section != ptrn::Pattern::InstantiationSectionId) {
+                    if (value->getSection() != ptrn::Pattern::InstantiationSectionId) {
                         if (heapSection || patternLocalSection) {
-                            u64 baseAddress = 0;
-                            if (section == ptrn::Pattern::MainSectionId)
-                                baseAddress = getDataBaseAddress();
-                            storage.resize(((value->getOffset() - baseAddress) & 0xFFFF'FFFF) + value->getSize());
-                            this->readData(value->getOffset(), storage.data(), value->getSize(), section);
+                            storage.resize((pattern->getOffset() & 0xFFFF'FFFF) + value->getSize());
+                            this->readData(value->getOffset(), storage.data(), value->getSize(), value->getSection());
                         } else if (storage.size() < pattern->getOffset() + pattern->getSize()) {
                             storage.resize(pattern->getOffset() + pattern->getSize());
-                            this->readData(value->getOffset(), storage.data() + pattern->getOffset(), value->getSize(), section);
+                            this->readData(value->getOffset(), storage.data() + pattern->getOffset(), value->getSize(), value->getSection());
                         }
                     } else {
                         storage.resize(value->getSize());

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -708,13 +708,15 @@ namespace pl::core {
                     }
 
                     auto &storage = getStorage();
-                    if (value->getSection() != ptrn::Pattern::InstantiationSectionId) {
+                    auto section = value->getSection();
+                    if (section != ptrn::Pattern::InstantiationSectionId) {
                         if (heapSection || patternLocalSection) {
-                            storage.resize((value->getOffset() & 0xFFFF'FFFF) + value->getSize());
-                            this->readData(value->getOffset(), storage.data(), value->getSize(), value->getSection());
+                            u64 baseAddress = section ? 0 : getDataBaseAddress();
+                            storage.resize(((value->getOffset() - baseAddress) & 0xFFFF'FFFF) + value->getSize());
+                            this->readData(value->getOffset(), storage.data(), value->getSize(), section);
                         } else if (storage.size() < pattern->getOffset() + pattern->getSize()) {
                             storage.resize(pattern->getOffset() + pattern->getSize());
-                            this->readData(value->getOffset(), storage.data() + pattern->getOffset(), value->getSize(), value->getSection());
+                            this->readData(value->getOffset(), storage.data() + pattern->getOffset(), value->getSize(), section);
                         }
                     } else {
                         storage.resize(value->getSize());

--- a/lib/source/pl/core/evaluator.cpp
+++ b/lib/source/pl/core/evaluator.cpp
@@ -711,7 +711,9 @@ namespace pl::core {
                     auto section = value->getSection();
                     if (section != ptrn::Pattern::InstantiationSectionId) {
                         if (heapSection || patternLocalSection) {
-                            u64 baseAddress = section ? 0 : getDataBaseAddress();
+                            u64 baseAddress = 0;
+                            if (section == ptrn::Pattern::MainSectionId)
+                                baseAddress = getDataBaseAddress();
                             storage.resize(((value->getOffset() - baseAddress) & 0xFFFF'FFFF) + value->getSize());
                             this->readData(value->getOffset(), storage.data(), value->getSize(), section);
                         } else if (storage.size() < pattern->getOffset() + pattern->getSize()) {


### PR DESCRIPTION
The pattern language evaluator uses storage whose size is calculated using the value offset. When a base address has been set that is not zero, the storage allocated is set incorrectly. This PR attempts to correct this by detecting when the value is from the main section and in that case removing the base address from the offset so that the storage size becomes independent of the base address.