### PR TITLE
fix: imhex uses all memory

### DIFF
--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -972,6 +972,7 @@ namespace pl::core {
             statement = parseFunctionVariableDecl(true);
         } else if (m_curr[0].type == Token::Type::Keyword) {
             errorHere("Invalid {} found in function.", getFormattedToken(0));
+            next();
             return nullptr;
         } else {
             errorHere("Invalid function statement.");


### PR DESCRIPTION
Om March 19 I merged a commit that was supposed to improve message of error when an invalid keyword was found inside a function. It did that, but it also created a possible infinite loop while writing a function. The problem was that the current token was not being moved forward when encountering the error which made ImHex use more and more memory until my computer froze. The fix is a simple next() to advance the token.