### PR TITLE
fix: imhex uses all memory

### DIFF
--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -796,6 +796,8 @@ namespace pl::core {
 
         while (!sequence(tkn::Separator::RightBrace)) {
             auto statement = parseFunctionStatement();
+            if (hasErrors())
+                break;
             if (statement == nullptr)
                 continue;
 
@@ -970,13 +972,11 @@ namespace pl::core {
             statement = parseFunctionVariableDecl();
         } else if (sequence(tkn::Keyword::Const)) {
             statement = parseFunctionVariableDecl(true);
-        } else if (m_curr[0].type == Token::Type::Keyword) {
-            errorHere("Invalid {} found in function.", getFormattedToken(0));
-            next();
-            return nullptr;
         } else {
-            errorHere("Invalid function statement.");
-            next();
+            if (m_curr[0].type == Token::Type::Keyword)
+                errorHere("Invalid {} found in function.", getFormattedToken(0));
+            else
+                errorHere("Invalid function statement.");
             return nullptr;
         }
 
@@ -1268,6 +1268,8 @@ namespace pl::core {
         std::vector<hlp::safe_unique_ptr<ast::ASTNode>> tryBody, catchBody;
         while (!sequence(tkn::Separator::RightBrace)) {
             auto member = memberParser();
+            if (hasErrors())
+                break;
             if (member == nullptr)
                 continue;
 
@@ -1282,6 +1284,8 @@ namespace pl::core {
 
             while (!sequence(tkn::Separator::RightBrace)) {
                 auto member = memberParser();
+                if (hasErrors())
+                    break;
                 if (member == nullptr)
                     continue;
 
@@ -1935,7 +1939,7 @@ namespace pl::core {
         else if (oneOf(tkn::Keyword::Return, tkn::Keyword::Break, tkn::Keyword::Continue))
             member = parseFunctionControlFlowStatement();
         else if (m_curr[0].type == Token::Type::Keyword) {
-            errorHere("Invalid {} found in struct.", getFormattedToken(0));
+            errorHere("Invalid {} found in custom type.", getFormattedToken(0));
             return nullptr;
         } else {
             errorHere("Invalid struct member definition.");
@@ -2044,6 +2048,8 @@ namespace pl::core {
         this->m_currTemplateType.push_back(typeDecl);
         while (!sequence(tkn::Separator::RightBrace)) {
             auto member = parseMember();
+            if (hasErrors())
+                break;
             if(member == nullptr)
                 continue;
 
@@ -2315,6 +2321,8 @@ namespace pl::core {
 
         while (!sequence(tkn::Separator::RightBrace)) {
             auto entry = parseBitfieldEntry();
+            if (hasErrors())
+                break;
             if (entry == nullptr)
                 continue;
 


### PR DESCRIPTION
The issue is caused by loops like the following
```cpp
     while (!sequence(tkn::Separator::RightBrace)) {
            auto statement = parseFunctionStatement();
            if (statement == nullptr)
                continue;

            body.push_back(std::move(statement));
        }
```
so that if the function does nor advance the token pointer, the loop never ends even if errors are generated. Some of these loops solve that by calling
```cpp
          if (hasErrors())
                break;
```
in which case generating errors is enough to avoid the problem. In this fix I changed all potentially exploding loops to check for errors and I tested the result with all the types of variables that use the loops like try/catch, unions, conditionals, match statements , ... and the problem seems resolve for good.