### PR TITLE
fix: imhex uses all memory

### DIFF
--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -977,6 +977,7 @@ namespace pl::core {
                 errorHere("Invalid {} found in function.", getFormattedToken(0));
             else
                 errorHere("Invalid function statement.");
+            next();
             return nullptr;
         }
 
@@ -1938,11 +1939,11 @@ namespace pl::core {
             return parseTryCatchStatement([this] { return parseMember(); });
         else if (oneOf(tkn::Keyword::Return, tkn::Keyword::Break, tkn::Keyword::Continue))
             member = parseFunctionControlFlowStatement();
-        else if (m_curr[0].type == Token::Type::Keyword) {
-            errorHere("Invalid {} found in custom type.", getFormattedToken(0));
-            return nullptr;
-        } else {
-            errorHere("Invalid struct member definition.");
+        else  {
+            if (m_curr[0].type == Token::Type::Keyword)
+                errorHere("Invalid {} found in custom type.", getFormattedToken(0));
+            else
+                errorHere("Invalid struct member definition.");
             next();
             return nullptr;
         }


### PR DESCRIPTION
It appears that my attempt to patch all possible places that could create an infinite loop failed to notice cases like namespace parsing and possibly others. Being unable to guarantee that the error alone will stop the loops I am forced to also make sure that every result of the loop advances the cursor at least one token. I can't really say if this is going to finally fix this problem but just as before, all tests I ran showed that it is indeed the case.