### PR TITLE
Fix/archlinux fmt

### DIFF
--- a/lib/include/pl/core/errors/error.hpp
+++ b/lib/include/pl/core/errors/error.hpp
@@ -3,7 +3,7 @@
 #include <pl/helpers/types.hpp>
 #include <pl/core/location.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <string>
 #include <utility>

--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -18,7 +18,7 @@
 
 #include <pl/core/errors/result.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <functional>
 #include <map>


### PR DESCRIPTION
On ArchLinux Imhex is built using USE_SYSTEM_FMT which was updated to 12.2.0 last week. Part of the update makes it mandatory for code that needs to use fmt::format to include fmt/format.h explicitly because fmt/core.h is now equivalent to fmt/base.h. 

Note that Imhex uses the header only version when the system fmt is not used and with the header only version fmt/base.h also includes fmt/format.h so this is only needed for archlinux even if we update fmt to 12.2.0.