### PR TITLE
fix: archlinux builds fail

### DIFF
--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -18,7 +18,7 @@
 #include <pl/core/errors/runtime_errors.hpp>
 #include <pl/core/ast/ast_node_type_appilication.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <pl/pattern_language.hpp>
 

--- a/lib/include/pl/core/lexer.hpp
+++ b/lib/include/pl/core/lexer.hpp
@@ -5,7 +5,7 @@
 
 #include <pl/core/token.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <optional>
 #include <string>

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -6,7 +6,7 @@
 #include <pl/helpers/types.hpp>
 #include <pl/helpers/utils.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <wolv/utils/core.hpp>
 #include <wolv/utils/guards.hpp>


### PR DESCRIPTION
Some files were still using fmt/core.h but never had a chance to generate errors until now.