### PR TITLE
feat: Add a pluggable text codec for string patterns

### DIFF
--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -13,6 +13,7 @@
 
 #include <pl/core/log_console.hpp>
 #include <pl/core/token.hpp>
+#include <pl/core/string_encode_decode.hpp>
 #include <pl/api.hpp>
 
 #include <pl/core/errors/runtime_errors.hpp>
@@ -206,6 +207,41 @@ namespace pl::core {
         [[nodiscard]] std::map<std::string, Token::Literal> getOutVariables() const;
 
         void setDataSource(u64 baseAddress, size_t dataSize, std::function<void(u64, u8*, size_t)> readerFunction, std::optional<std::function<void(u64, const u8*, size_t)>> writerFunction = std::nullopt);
+
+        /**
+         * @brief Sets the text codec for string patterns
+         * @param codec Codec to set. Pass nullptr to go back to raw bytes.
+         */
+        void setStringEncodeDecode(std::shared_ptr<StringEncodeDecode> codec) {
+            this->m_stringEncodeDecode = std::move(codec);
+        }
+
+        /**
+         * @brief Gets the text codec set for string patterns
+         * @return The codec, or nullptr when none is set
+         */
+        [[nodiscard]] const std::shared_ptr<StringEncodeDecode>& getStringEncodeDecode() const {
+            return this->m_stringEncodeDecode;
+        }
+
+        /**
+         * @brief Sets the default encoding a string pattern with no [[encoding]]
+         * attribute of its own resolves to
+         * @param encoding Encoding name to set. Empty lets the codec pick its own
+         * default.
+         */
+        void setDefaultEncoding(std::string encoding) {
+            this->m_defaultEncoding = std::move(encoding);
+        }
+
+        /**
+         * @brief Gets the default encoding a string pattern with no [[encoding]]
+         * attribute of its own resolves to
+         * @return The encoding name, empty when none is set
+         */
+        [[nodiscard]] const std::string& getDefaultEncoding() const {
+            return this->m_defaultEncoding;
+        }
 
         void setDataBaseAddress(u64 baseAddress) {
             this->m_dataBaseAddress = baseAddress;
@@ -556,6 +592,8 @@ namespace pl::core {
         std::vector<std::unique_ptr<ast::ASTNode>> m_currentTemplateArguments;
 
         std::function<bool()> m_dangerousFunctionCalledCallback = []{ return false; };
+        std::shared_ptr<StringEncodeDecode> m_stringEncodeDecode;
+        std::string m_defaultEncoding;
         std::function<void()> m_breakpointHitCallback = []{ };
         std::atomic<DangerousFunctionPermission> m_allowDangerousFunctions = DangerousFunctionPermission::Ask;
         ControlFlowStatement m_currControlFlowStatement = ControlFlowStatement::None;

--- a/lib/include/pl/core/evaluator.hpp
+++ b/lib/include/pl/core/evaluator.hpp
@@ -233,9 +233,19 @@ namespace pl::core {
          * attribute of its own resolves to
          * @param encoding Encoding name to set. Empty lets the codec pick its own
          * default.
+         * @return false when a validator set through setEncodingValidator() rejects
+         * `encoding`; the default encoding is left unchanged in that case.
          */
-        void setDefaultEncoding(std::string encoding) {
+        bool setDefaultEncoding(std::string encoding) {
+            if (this->m_encodingValidator != nullptr && !this->m_encodingValidator(encoding))
+                return false;
+
             this->m_defaultEncoding = std::move(encoding);
+
+            if (this->m_onDefaultEncodingChanged != nullptr)
+                this->m_onDefaultEncodingChanged(this->m_defaultEncoding);
+
+            return true;
         }
 
         /**
@@ -245,6 +255,25 @@ namespace pl::core {
          */
         [[nodiscard]] const std::string& getDefaultEncoding() const {
             return this->m_defaultEncoding;
+        }
+
+        /**
+         * @brief Sets a host-supplied check for whether an encoding name means
+         * anything. #pragma encoding fails when this rejects its value.
+         * @param validator Called with a candidate encoding name. Pass nullptr
+         * (the default) to accept any name.
+         */
+        void setEncodingValidator(std::function<bool(const std::string&)> validator) {
+            this->m_encodingValidator = std::move(validator);
+        }
+
+        /**
+         * @brief Sets a callback invoked whenever setDefaultEncoding() actually
+         * changes the default encoding, after it passes any validator
+         * @param callback Called with the new encoding name
+         */
+        void setOnDefaultEncodingChanged(std::function<void(const std::string&)> callback) {
+            this->m_onDefaultEncodingChanged = std::move(callback);
         }
 
         void setDataBaseAddress(u64 baseAddress) {
@@ -598,6 +627,8 @@ namespace pl::core {
         std::function<bool()> m_dangerousFunctionCalledCallback = []{ return false; };
         std::shared_ptr<StringEncodeDecode> m_stringEncodeDecode;
         std::string m_defaultEncoding;
+        std::function<bool(const std::string&)> m_encodingValidator;
+        std::function<void(const std::string&)> m_onDefaultEncodingChanged;
         std::function<void()> m_breakpointHitCallback = []{ };
         std::atomic<DangerousFunctionPermission> m_allowDangerousFunctions = DangerousFunctionPermission::Ask;
         ControlFlowStatement m_currControlFlowStatement = ControlFlowStatement::None;

--- a/lib/include/pl/core/string_encode_decode.hpp
+++ b/lib/include/pl/core/string_encode_decode.hpp
@@ -10,6 +10,20 @@
 
 namespace pl::core {
 
+    /// Why decode() stopped before the end of `bytes`.
+    enum class DecodeStop {
+        EndOfInput,      ///< Consumed every byte given
+        CodepointLimit,  ///< Reached maxCodepoints; more input may remain
+        MalformedBytes,  ///< The byte sequence at bytesConsumed is not valid under this encoding
+    };
+
+    struct DecodeResult {
+        std::string text;                              ///< Whole code points only, never a mid-sequence fragment
+        size_t bytesConsumed = 0;                       ///< How much of the input `text` accounts for
+        size_t codepointCount = 0;                      ///< Code points in `text`
+        DecodeStop stopReason = DecodeStop::EndOfInput;
+    };
+
     /**
      * @brief A pluggable text codec for string patterns
      * @note The host application sets this on the Evaluator. With none set, string
@@ -20,14 +34,17 @@ namespace pl::core {
         virtual ~StringEncodeDecode() = default;
 
         /**
-         * @brief Decodes `bytes` under `encoding`
+         * @brief Decodes `bytes` under `encoding`, one code point at a time
          * @param bytes Bytes to decode
          * @param encoding Encoding to decode with; empty when the pattern names no
          * encoding, in which case the codec picks its own default
-         * @return The decoded text, or std::nullopt when `bytes` is not valid under
-         * `encoding`
+         * @param maxCodepoints Stop after decoding this many code points. std::nullopt
+         * decodes as much of `bytes` as is valid, with no cap.
+         * @return Code points decoded up to the first malformed byte, the end of
+         * `bytes`, or maxCodepoints - whichever comes first. `stopReason` says which.
          */
-        [[nodiscard]] virtual std::optional<std::string> decode(std::span<const u8> bytes, std::string_view encoding) const = 0;
+        [[nodiscard]] virtual DecodeResult decode(std::span<const u8> bytes, std::string_view encoding,
+            std::optional<size_t> maxCodepoints = std::nullopt) const = 0;
 
         /**
          * @brief Encodes `text` under `encoding`

--- a/lib/include/pl/core/string_encode_decode.hpp
+++ b/lib/include/pl/core/string_encode_decode.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <pl/helpers/types.hpp>
+
+namespace pl::core {
+
+    /**
+     * @brief A pluggable text codec for string patterns
+     * @note The host application sets this on the Evaluator. With none set, string
+     * patterns keep their old raw-byte behavior.
+     */
+    class StringEncodeDecode {
+    public:
+        virtual ~StringEncodeDecode() = default;
+
+        /**
+         * @brief Decodes `bytes` under `encoding`
+         * @param bytes Bytes to decode
+         * @param encoding Encoding to decode with; empty when the pattern names no
+         * encoding, in which case the codec picks its own default
+         * @return The decoded text, or std::nullopt when `bytes` is not valid under
+         * `encoding`
+         */
+        [[nodiscard]] virtual std::optional<std::string> decode(std::span<const u8> bytes, std::string_view encoding) const = 0;
+
+        /**
+         * @brief Encodes `text` under `encoding`
+         * @param text Text to encode
+         * @param encoding Encoding to encode with; empty when the pattern names no
+         * encoding, in which case the codec picks its own default
+         * @return The encoded bytes, or std::nullopt when `text` is not representable
+         * under `encoding`
+         */
+        [[nodiscard]] virtual std::optional<std::vector<u8>> encode(std::string_view text, std::string_view encoding) const = 0;
+
+        /**
+         * @brief Encodes `text` under `encoding`, never failing
+         * @param text Text to encode
+         * @param encoding Encoding to encode with; empty when the pattern names no
+         * encoding, in which case the codec picks its own default
+         * @return The encoded bytes, substituting a replacement for anything `encoding`
+         * cannot represent
+         */
+        [[nodiscard]] virtual std::vector<u8> encodeLossy(std::string_view text, std::string_view encoding) const = 0;
+    };
+
+}

--- a/lib/include/pl/core/string_encode_decode.hpp
+++ b/lib/include/pl/core/string_encode_decode.hpp
@@ -10,17 +10,28 @@
 
 namespace pl::core {
 
-    /// Why decode() stopped before the end of `bytes`.
+    /**
+     * @brief Why decode() stopped before the end of `bytes`
+     * @var DecodeStop::EndOfInput Consumed every byte given
+     * @var DecodeStop::CodepointLimit Reached maxCodepoints; more input may remain
+     * @var DecodeStop::MalformedBytes The byte sequence at bytesConsumed is not valid under this encoding
+     */
     enum class DecodeStop {
-        EndOfInput,      ///< Consumed every byte given
-        CodepointLimit,  ///< Reached maxCodepoints; more input may remain
-        MalformedBytes,  ///< The byte sequence at bytesConsumed is not valid under this encoding
+        EndOfInput,
+        CodepointLimit,
+        MalformedBytes,
     };
 
+    /**
+     * @brief The result of decode()
+     * @var DecodeResult::text Whole code points only, never a mid-sequence fragment
+     * @var DecodeResult::bytesConsumed How much of the input `text` accounts for
+     * @var DecodeResult::codepointCount Code points in `text`
+     */
     struct DecodeResult {
-        std::string text;                              ///< Whole code points only, never a mid-sequence fragment
-        size_t bytesConsumed = 0;                       ///< How much of the input `text` accounts for
-        size_t codepointCount = 0;                      ///< Code points in `text`
+        std::string text;
+        size_t bytesConsumed = 0;
+        size_t codepointCount = 0;
         DecodeStop stopReason = DecodeStop::EndOfInput;
     };
 

--- a/lib/include/pl/pattern_language.hpp
+++ b/lib/include/pl/pattern_language.hpp
@@ -13,6 +13,7 @@
 #include <pl/api.hpp>
 
 #include <pl/core/log_console.hpp>
+#include <pl/core/string_encode_decode.hpp>
 #include <pl/core/token.hpp>
 #include <pl/core/errors/error.hpp>
 #include <pl/core/resolver.hpp>
@@ -148,6 +149,38 @@ namespace pl {
          * @param baseAddress Base address of the data source
          */
         void setDataBaseAddress(u64 baseAddress);
+
+        /**
+         * @brief Sets the text codec for string patterns
+         * @param codec Codec to set. Pass nullptr to go back to raw bytes.
+         */
+        void setStringEncodeDecode(std::shared_ptr<core::StringEncodeDecode> codec);
+
+        /**
+         * @brief Sets a host-supplied check for whether an encoding name means
+         * anything. #pragma encoding fails when this rejects its value.
+         * @param validator Called with a candidate encoding name. Pass nullptr
+         * (the default) to accept any name.
+         */
+        void setEncodingValidator(std::function<bool(const std::string&)> validator);
+
+        /**
+         * @brief Sets the default encoding a string pattern with no [[encoding]]
+         * attribute of its own resolves to
+         * @param encoding Encoding name to set. Empty lets the codec pick its own
+         * default.
+         * @return false when a validator set through the evaluator's
+         * setEncodingValidator() rejects `encoding`; the default encoding is left
+         * unchanged in that case.
+         */
+        bool setDefaultEncoding(std::string encoding);
+
+        /**
+         * @brief Sets a callback invoked whenever setDefaultEncoding() actually
+         * changes the default encoding, after it passes any validator
+         * @param callback Called with the new encoding name
+         */
+        void setOnDefaultEncodingChanged(std::function<void(const std::string&)> callback);
 
         /**
          * @brief Sets the size of the data source

--- a/lib/include/pl/pattern_language.hpp
+++ b/lib/include/pl/pattern_language.hpp
@@ -295,6 +295,14 @@ namespace pl {
         void reset();
 
         /**
+         * @brief Clears every placed pattern's cached display value, across every section.
+         * Call this after changing something a pattern's formatted value depends on
+         * without re-running the pattern, such as the host application's declared
+         * string encoding.
+         */
+        void clearFormatCaches();
+
+        /**
          * @brief Checks whether the runtime is currently running
          * @return True if the runtime is running, false otherwise
          */

--- a/lib/include/pl/patterns/pattern.hpp
+++ b/lib/include/pl/patterns/pattern.hpp
@@ -484,6 +484,7 @@ namespace pl::ptrn {
             if (!result.empty()) {
                 this->getEvaluator()->writeData(this->getOffset(), result.data(), result.size(), this->getSection());
                 this->clearFormatCache();
+                this->clearByteCache();
             }
         }
 

--- a/lib/include/pl/patterns/pattern_string.hpp
+++ b/lib/include/pl/patterns/pattern_string.hpp
@@ -57,10 +57,10 @@ namespace pl::ptrn {
             if (const auto &codec = evaluator->getStringEncodeDecode(); codec != nullptr) {
                 const auto encoding = this->getEncodingName();
                 auto decoded = codec->decode({ reinterpret_cast<const u8*>(buffer.data()), buffer.size() }, encoding);
-                if (!decoded.has_value())
+                if (decoded.bytesConsumed != buffer.size())
                     core::err::E0004.throwError(fmt::format("invalid byte sequence for encoding '{}'", encoding));
 
-                return *decoded;
+                return decoded.text;
             }
 
             return buffer;
@@ -132,14 +132,15 @@ namespace pl::ptrn {
             auto *evaluator = this->getEvaluator();
             const auto fullSize = this->getSize();
 
-            // Read a little past DisplayBudget, so a multi-byte codepoint at the
-            // cutoff usually has the bytes to decode whole. The decode below still
-            // backs off further on failure; this only keeps that the common case.
-            constexpr size_t DisplayBudget = 0x7F;
-            auto size = std::min<size_t>(fullSize, DisplayBudget + 8);
-
-            if (size == 0)
+            if (fullSize == 0)
                 return "\"\"";
+
+            constexpr size_t DisplayBudget = 0x7F;
+
+            // UTF-32, the widest encoding decode() supports, spends 4 bytes per
+            // code point. This margin holds DisplayBudget code points under any
+            // of them.
+            auto size = std::min<size_t>(fullSize, DisplayBudget * 4);
 
             std::string buffer(size, 0x00);
             evaluator->readData(this->getOffset(), buffer.data(), size, this->getSection());
@@ -148,12 +149,13 @@ namespace pl::ptrn {
                 return *formatted;
 
             const auto &codec = evaluator->getStringEncodeDecode();
-            bool truncated = size < fullSize;
 
             // No codec configured keeps the old raw-byte display, unescaped by any
             // encoding. A configured codec reports an undecodable buffer as invalid,
             // rather than substituting a replacement character into the display.
             if (codec == nullptr) {
+                bool truncated = size < fullSize;
+
                 if (buffer.size() > DisplayBudget) {
                     buffer.resize(DisplayBudget);
                     truncated = true;
@@ -168,33 +170,13 @@ namespace pl::ptrn {
             }
 
             const auto encoding = this->getEncodingName();
+            const auto decoded = codec->decode({ reinterpret_cast<const u8*>(buffer.data()), buffer.size() }, encoding, DisplayBudget);
 
-            // The read above can itself end mid-codepoint. decode() fails on the whole
-            // buffer in that case, not just its incomplete tail, so back off a few
-            // bytes and retry rather than reporting a merely-truncated read as invalid.
-            std::optional<std::string> decoded;
-            for (size_t backoff = 0; backoff <= std::min<size_t>(4, buffer.size()); ++backoff) {
-                decoded = codec->decode({ reinterpret_cast<const u8*>(buffer.data()), buffer.size() - backoff }, encoding);
-                if (decoded.has_value()) {
-                    if (backoff > 0)
-                        truncated = true;
-                    break;
-                }
-            }
-            if (!decoded.has_value())
+            if (decoded.stopReason == core::DecodeStop::MalformedBytes)
                 core::err::E0004.throwError(fmt::format("invalid byte sequence for encoding '{}'", encoding));
 
-            // Trim the decoded text itself, not the raw bytes, so a multi-byte
-            // codepoint at the cutoff stays whole instead of splitting mid-sequence.
-            if (decoded->size() > DisplayBudget) {
-                auto cut = DisplayBudget;
-                while (cut > 0 && (static_cast<u8>((*decoded)[cut]) & 0xC0) == 0x80)
-                    --cut;
-                decoded->resize(cut);
-                truncated = true;
-            }
-
-            return fmt::format("\"{0}\" {1}", *decoded, truncated ? "(truncated)" : "");
+            const bool truncated = decoded.bytesConsumed < fullSize;
+            return fmt::format("\"{0}\" {1}", decoded.text, truncated ? "(truncated)" : "");
         }
 
         std::shared_ptr<Pattern> getEntry(size_t index) const override {

--- a/lib/include/pl/patterns/pattern_string.hpp
+++ b/lib/include/pl/patterns/pattern_string.hpp
@@ -3,6 +3,7 @@
 #include <pl/patterns/pattern.hpp>
 
 #include <pl/patterns/pattern_character.hpp>
+#include <pl/core/errors/runtime_errors.hpp>
 
 namespace pl::ptrn {
 
@@ -32,21 +33,82 @@ namespace pl::ptrn {
 
         }
 
+        /**
+         * @brief Gets this string's own encoding
+         * @return This pattern's own [[encoding]] attribute, the evaluator's default
+         * encoding if none, or empty when neither is set. An empty result falls back
+         * to the codec's own default.
+         */
+        [[nodiscard]] std::string getEncodingName() const {
+            if (const auto &arguments = this->getAttributeArguments("encoding"); !arguments.empty())
+                return arguments[0].toString(true);
+            return this->getEvaluator()->getDefaultEncoding();
+        }
+
         std::string getValue(size_t size) const {
             if (size == 0)
                 return "";
 
+            auto *evaluator = this->getEvaluator();
+
             std::string buffer(size, '\x00');
-            this->getEvaluator()->readData(this->getOffset(), buffer.data(), size, this->getSection());
+            evaluator->readData(this->getOffset(), buffer.data(), size, this->getSection());
+
+            if (const auto &codec = evaluator->getStringEncodeDecode(); codec != nullptr) {
+                const auto encoding = this->getEncodingName();
+                auto decoded = codec->decode({ reinterpret_cast<const u8*>(buffer.data()), buffer.size() }, encoding);
+                if (!decoded.has_value())
+                    core::err::E0004.throwError(fmt::format("invalid byte sequence for encoding '{}'", encoding));
+
+                return *decoded;
+            }
 
             return buffer;
         }
 
         std::vector<u8> getBytesOf(const core::Token::Literal &value) const override {
-            if (auto stringValue = std::get_if<std::string>(&value); stringValue != nullptr)
-                return { stringValue->begin(), stringValue->end() };
-            else
+            if (auto stringValue = std::get_if<std::string>(&value); stringValue != nullptr) {
+                std::vector<u8> bytes;
+
+                if (const auto &codec = this->getEvaluator()->getStringEncodeDecode(); codec != nullptr) {
+                    const auto encoding = this->getEncodingName();
+                    auto encoded = codec->encode(*stringValue, encoding);
+                    if (!encoded.has_value())
+                        core::err::E0004.throwError(fmt::format("text has no byte value in encoding '{}'", encoding));
+
+                    bytes = *encoded;
+                } else {
+                    bytes = { stringValue->begin(), stringValue->end() };
+                }
+
+                // This field owns a fixed number of bytes in the file. A longer write would
+                // overwrite whatever comes right after it. Truncate or pad with NUL to the
+                // field's own size, the same contract every other pattern type already has.
+                bytes.resize(this->getSize());
+                return bytes;
+            } else
                 return { };
+        }
+
+        /**
+         * @brief Force-writes `value`, substituting a replacement character for
+         * anything the pattern's encoding cannot represent
+         * @param value Value to write
+         * @note setValue() rejects such a value instead; an editor that offers an
+         * explicit lossy override calls this one directly.
+         */
+        void setValueLossy(const std::string &value) {
+            std::vector<u8> bytes;
+
+            if (const auto &codec = this->getEvaluator()->getStringEncodeDecode(); codec != nullptr)
+                bytes = codec->encodeLossy(value, this->getEncodingName());
+            else
+                bytes = { value.begin(), value.end() };
+
+            bytes.resize(this->getSize());
+            this->getEvaluator()->writeData(this->getOffset(), bytes.data(), bytes.size(), this->getSection());
+            this->clearFormatCache();
+            this->clearByteCache();
         }
 
         [[nodiscard]] std::string getFormattedName() const override {
@@ -67,23 +129,72 @@ namespace pl::ptrn {
         }
 
         std::string formatDisplayValue() override {
-            auto size = std::min<size_t>(this->getSize(), 0x7F);
+            auto *evaluator = this->getEvaluator();
+            const auto fullSize = this->getSize();
+
+            // Read a little past DisplayBudget, so a multi-byte codepoint at the
+            // cutoff usually has the bytes to decode whole. The decode below still
+            // backs off further on failure; this only keeps that the common case.
+            constexpr size_t DisplayBudget = 0x7F;
+            auto size = std::min<size_t>(fullSize, DisplayBudget + 8);
 
             if (size == 0)
                 return "\"\"";
 
             std::string buffer(size, 0x00);
-            this->getEvaluator()->readData(this->getOffset(), buffer.data(), size, this->getSection());
+            evaluator->readData(this->getOffset(), buffer.data(), size, this->getSection());
 
-            const auto pos = buffer.find_last_not_of('\x00');
-            if (pos == std::string::npos)
-                return "\"\"";
+            if (auto formatted = Pattern::callUserFormatFunc(buffer); formatted.has_value())
+                return *formatted;
 
-            buffer.erase(pos + 1);
+            const auto &codec = evaluator->getStringEncodeDecode();
+            bool truncated = size < fullSize;
 
-            auto displayString = hlp::encodeByteString({ buffer.begin(), buffer.end() });
+            // No codec configured keeps the old raw-byte display, unescaped by any
+            // encoding. A configured codec reports an undecodable buffer as invalid,
+            // rather than substituting a replacement character into the display.
+            if (codec == nullptr) {
+                if (buffer.size() > DisplayBudget) {
+                    buffer.resize(DisplayBudget);
+                    truncated = true;
+                }
 
-            return Pattern::callUserFormatFunc(buffer).value_or(fmt::format("\"{0}\" {1}", displayString, size > this->getSize() ? "(truncated)" : ""));
+                const auto pos = buffer.find_last_not_of('\x00');
+                if (pos == std::string::npos)
+                    return "\"\"";
+                buffer.erase(pos + 1);
+
+                return fmt::format("\"{0}\" {1}", hlp::encodeByteString({ buffer.begin(), buffer.end() }), truncated ? "(truncated)" : "");
+            }
+
+            const auto encoding = this->getEncodingName();
+
+            // The read above can itself end mid-codepoint. decode() fails on the whole
+            // buffer in that case, not just its incomplete tail, so back off a few
+            // bytes and retry rather than reporting a merely-truncated read as invalid.
+            std::optional<std::string> decoded;
+            for (size_t backoff = 0; backoff <= std::min<size_t>(4, buffer.size()); ++backoff) {
+                decoded = codec->decode({ reinterpret_cast<const u8*>(buffer.data()), buffer.size() - backoff }, encoding);
+                if (decoded.has_value()) {
+                    if (backoff > 0)
+                        truncated = true;
+                    break;
+                }
+            }
+            if (!decoded.has_value())
+                core::err::E0004.throwError(fmt::format("invalid byte sequence for encoding '{}'", encoding));
+
+            // Trim the decoded text itself, not the raw bytes, so a multi-byte
+            // codepoint at the cutoff stays whole instead of splitting mid-sequence.
+            if (decoded->size() > DisplayBudget) {
+                auto cut = DisplayBudget;
+                while (cut > 0 && (static_cast<u8>((*decoded)[cut]) & 0xC0) == 0x80)
+                    --cut;
+                decoded->resize(cut);
+                truncated = true;
+            }
+
+            return fmt::format("\"{0}\" {1}", *decoded, truncated ? "(truncated)" : "");
         }
 
         std::shared_ptr<Pattern> getEntry(size_t index) const override {

--- a/lib/source/pl/lib/std/pragmas.cpp
+++ b/lib/source/pl/lib/std/pragmas.cpp
@@ -39,7 +39,7 @@ namespace pl::lib::libstd {
         });
 
         runtime.addPragma("encoding", [](pl::PatternLanguage &runtime, const std::string &value) {
-            return runtime.getInternals().evaluator->setDefaultEncoding(value);
+            return runtime.setDefaultEncoding(value);
         });
 
         runtime.addPragma("eval_depth", [](pl::PatternLanguage &runtime, const std::string &value) {

--- a/lib/source/pl/lib/std/pragmas.cpp
+++ b/lib/source/pl/lib/std/pragmas.cpp
@@ -38,6 +38,11 @@ namespace pl::lib::libstd {
                 return false;
         });
 
+        runtime.addPragma("encoding", [](pl::PatternLanguage &runtime, const std::string &value) {
+            runtime.getInternals().evaluator->setDefaultEncoding(value);
+            return true;
+        });
+
         runtime.addPragma("eval_depth", [](pl::PatternLanguage &runtime, const std::string &value) {
             auto limit = parseLimit(value);
             if (!limit.has_value())

--- a/lib/source/pl/lib/std/pragmas.cpp
+++ b/lib/source/pl/lib/std/pragmas.cpp
@@ -39,8 +39,7 @@ namespace pl::lib::libstd {
         });
 
         runtime.addPragma("encoding", [](pl::PatternLanguage &runtime, const std::string &value) {
-            runtime.getInternals().evaluator->setDefaultEncoding(value);
-            return true;
+            return runtime.getInternals().evaluator->setDefaultEncoding(value);
         });
 
         runtime.addPragma("eval_depth", [](pl::PatternLanguage &runtime, const std::string &value) {

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -427,6 +427,22 @@ namespace pl {
         this->m_dataBaseAddress = baseAddress;
     }
 
+    void PatternLanguage::setStringEncodeDecode(std::shared_ptr<core::StringEncodeDecode> codec) {
+        this->m_internals.evaluator->setStringEncodeDecode(std::move(codec));
+    }
+
+    void PatternLanguage::setEncodingValidator(std::function<bool(const std::string&)> validator) {
+        this->m_internals.evaluator->setEncodingValidator(std::move(validator));
+    }
+
+    bool PatternLanguage::setDefaultEncoding(std::string encoding) {
+        return this->m_internals.evaluator->setDefaultEncoding(std::move(encoding));
+    }
+
+    void PatternLanguage::setOnDefaultEncodingChanged(std::function<void(const std::string&)> callback) {
+        this->m_internals.evaluator->setOnDefaultEncodingChanged(std::move(callback));
+    }
+
     void PatternLanguage::setDataSize(u64 size) {
         this->m_dataSize = size;
     }

--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -533,6 +533,13 @@ namespace pl {
         this->m_parserManager.setPatternLanguage(this);
     }
 
+    void PatternLanguage::clearFormatCaches() {
+        for (const auto &[section, patterns] : this->m_patterns) {
+            for (const auto &pattern : patterns)
+                pattern->clearFormatCache();
+        }
+    }
+
     void PatternLanguage::addFunction(const api::Namespace &ns, const std::string &name, api::FunctionParameterCount parameterCount, const api::FunctionCallback &func) {
         this->m_functions.emplace_back(ns, name, parameterCount, func, false);
     }


### PR DESCRIPTION
Add `StringEncodeDecode`: an interface with `decode()`, `encode()`, and `encodeLossy()`. The host application sets one on the Evaluator. With none set, a string pattern keeps its raw-byte behavior.

- `decode()` and `encode()` return `std::optional`. A `nullopt` result marks a byte sequence, or a character, the named encoding cannot represent.
- `encodeLossy()` never fails. It substitutes a replacement character for anything the encoding cannot represent.
- `PatternString` routes reads and writes through the codec. `getValue()` and `getBytesOf()` throw `core::err::E0004` on a `nullopt` result. A script can catch this error with try/catch.
- `setValueLossy()` writes through `encodeLossy()`, and clears the cached bytes and the cached display string; `getBytesOf()` otherwise reflects a write only after the next pattern run.
- `setValue()` clears the cached bytes the same way, on every pattern type, not just `PatternString`.
- `formatDisplayValue()` decodes through `decode()`. It returns the raw decoded text. The host application escapes the text for display.
- `getBytesOf()` caps the encoded result to the pattern's own size. 
- `getEncodingName()` reads the string's own `encoding` attribute.
- `PatternWideString` keeps its fixed UTF-16 behavior. The codec does not apply to it.
- `PatternLanguage::clearFormatCaches()` clears every placed pattern's cached display value, across every section.