### PR TITLE
fix: Compound assignments for rvalued variables and null deref

### DIFF
--- a/lib/include/pl/core/errors/error.hpp
+++ b/lib/include/pl/core/errors/error.hpp
@@ -182,6 +182,10 @@ namespace pl::core::err {
             return this->m_errors;
         }
 
+        void setErrors(std::vector<CompileError> errors) {
+            this->m_errors = errors;
+        }
+
         [[nodiscard]] std::vector<CompileError> collectErrors() {
             return std::move(this->m_errors);
         }

--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -173,6 +173,7 @@ namespace pl::core {
         hlp::safe_unique_ptr<ast::ASTNode> parseFunctionStatement(bool needsSemicolon = true);
         hlp::safe_unique_ptr<ast::ASTNode> parseFunctionVariableAssignment(const std::string &lvalue);
         hlp::safe_unique_ptr<ast::ASTNode> parseFunctionVariableCompoundAssignment(const std::string &lvalue);
+        hlp::safe_unique_ptr<ast::ASTNode> parseFunctionVariableCompoundAssignment(TokenIter curr);
         hlp::safe_unique_ptr<ast::ASTNode> parseFunctionControlFlowStatement();
         std::vector<hlp::safe_unique_ptr<ast::ASTNode>> parseStatementBody(const std::function<hlp::safe_unique_ptr<ast::ASTNode>()> &memberParser);
         hlp::safe_unique_ptr<ast::ASTNode> parseFunctionWhileLoop();
@@ -210,7 +211,9 @@ namespace pl::core {
         std::vector<hlp::safe_shared_ptr<ast::ASTNode>> parseNamespace();
         std::vector<hlp::safe_shared_ptr<ast::ASTNode>> parseStatements();
 
-        std::optional<i32> parseCompoundAssignment(const Token &token);
+        std::optional<i32> isCompoundAssignmentOperator(const Token &token);
+        std::optional<TokenIter> isCompoundAssignmentOperator();
+        std::optional<i32>  isCompoundAssignmentOperator(i32 offset);
 
         std::optional<Token::DocComment> parseDocComment(bool global);
 

--- a/lib/include/pl/core/parser.hpp
+++ b/lib/include/pl/core/parser.hpp
@@ -71,6 +71,13 @@ namespace pl::core {
         std::string m_aliasNamespaceString;
         std::string m_autoNamespace;
 
+        enum class AllowKeywords : u8 {
+            None = 0,
+            Parent,
+            This,
+            Both
+        };
+
         Location location() override;
         // error helpers
         void errorHere(const std::string &message);
@@ -212,7 +219,7 @@ namespace pl::core {
         std::vector<hlp::safe_shared_ptr<ast::ASTNode>> parseStatements();
 
         std::optional<i32> isCompoundAssignmentOperator(const Token &token);
-        std::optional<TokenIter> isCompoundAssignmentOperator();
+        std::optional<TokenIter> isCompoundAssignmentOperator(AllowKeywords allowKeywords = AllowKeywords::None);
         std::optional<i32>  isCompoundAssignmentOperator(i32 offset);
 
         std::optional<Token::DocComment> parseDocComment(bool global);

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -936,7 +936,7 @@ namespace pl::core {
             statement = parseFunctionVariableAssignment("$");
         else if (const auto identifierOffset = isCompoundAssignmentOperator(tkn::Literal::Identifier); identifierOffset.has_value())
             statement = parseFunctionVariableCompoundAssignment(getValue<Token::Identifier>(*identifierOffset).get());
-        else if (const auto curr = isCompoundAssignmentOperator(); curr.has_value())
+        else if (const auto curr = isCompoundAssignmentOperator(AllowKeywords::Parent); curr.has_value())
             statement = parseFunctionVariableCompoundAssignment(curr.value());
         else if (isCompoundAssignmentOperator(tkn::Operator::Dollar).has_value())
             statement = parseFunctionVariableCompoundAssignment("$");
@@ -957,7 +957,7 @@ namespace pl::core {
         } else if (sequence(tkn::Keyword::For, tkn::Separator::LeftParenthesis)) {
             statement      = parseFunctionForLoop();
             needsSemicolon = false;
-        } else if (MATCHES(sequence(tkn::Literal::Identifier) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1))))) {
+        } else if (MATCHES((sequence(tkn::Literal::Identifier) || sequence(tkn::Keyword::Parent)) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1))))) {
             statement = parseRValueAssignment();
         } else if (sequence(tkn::Literal::Identifier)) {
             const auto originalPos = this->m_curr;
@@ -1916,7 +1916,7 @@ namespace pl::core {
             member = parseFunctionVariableAssignment(getValue<Token::Identifier>(-2).get());
         } else if (const auto identifierOffset = isCompoundAssignmentOperator(tkn::Literal::Identifier); identifierOffset.has_value())
             member = parseFunctionVariableCompoundAssignment(getValue<Token::Identifier>(*identifierOffset).get());
-        else if (const auto curr = isCompoundAssignmentOperator(); curr.has_value())
+        else if (const auto curr = isCompoundAssignmentOperator(AllowKeywords::Both); curr.has_value())
             member = parseFunctionVariableCompoundAssignment(curr.value());
         else if (MATCHES((sequence(tkn::Literal::Identifier) || sequence(tkn::Keyword::Parent) || sequence(tkn::Keyword::This)) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1)))))
             member = parseRValueAssignment();
@@ -2190,8 +2190,10 @@ namespace pl::core {
             member = parseFunctionVariableAssignment(variableName);
         } else if (const auto identifierOffset = isCompoundAssignmentOperator(tkn::Literal::Identifier); identifierOffset.has_value())
             member = parseFunctionVariableCompoundAssignment(getValue<Token::Identifier>(*identifierOffset).get());
-        else if (const auto curr = isCompoundAssignmentOperator(); curr.has_value())
+        else if (const auto curr = isCompoundAssignmentOperator(AllowKeywords::Parent); curr.has_value())
             member = parseFunctionVariableCompoundAssignment(curr.value());
+        else if (MATCHES((sequence(tkn::Literal::Identifier) || sequence(tkn::Keyword::Parent)) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1)))))
+            member = parseRValueAssignment();
         else if (MATCHES(optional(tkn::Keyword::Unsigned) && sequence(tkn::Literal::Identifier, tkn::Operator::Colon))) {
             auto fieldName = getValue<Token::Identifier>(-2).get();
             auto identifier = std::get_if<Token::Identifier>(&((m_curr[-2]).value));
@@ -2677,6 +2679,8 @@ namespace pl::core {
             statement = parseFunctionVariableCompoundAssignment(getValue<Token::Identifier>(*identifierOffset).get());
         else if (const auto curr = isCompoundAssignmentOperator(); curr.has_value())
             statement = parseFunctionVariableCompoundAssignment(curr.value());
+        else if (MATCHES(sequence(tkn::Literal::Identifier) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1)))))
+            statement = parseRValueAssignment();
         else if (MATCHES(sequence(tkn::Keyword::Using, tkn::Literal::Identifier)))
             statement = parseUsingDeclaration();
         else if (sequence(tkn::Keyword::Import))
@@ -2765,10 +2769,11 @@ namespace pl::core {
         return std::nullopt;
     }
 
-    std::optional<Parser::TokenIter>  Parser::isCompoundAssignmentOperator() {
+    std::optional<Parser::TokenIter>  Parser::isCompoundAssignmentOperator(AllowKeywords allowKeywords) {
         auto save = this->m_curr;
-
-        if (MATCHES(sequence(tkn::Literal::Identifier) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1))))) {
+        bool allowParent = ((u32)allowKeywords & (u32)AllowKeywords::Parent) != 0;
+        bool allowThis   = ((u32)allowKeywords & (u32)AllowKeywords::This) != 0;
+        if (MATCHES((sequence(tkn::Literal::Identifier) || (allowParent && sequence(tkn::Keyword::Parent)) || (allowThis && sequence(tkn::Keyword::This))) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1))))) {
             auto result = m_curr;
             auto lhs = parseRValue();
             if (lhs == nullptr) {

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -934,9 +934,11 @@ namespace pl::core {
             statement = parseFunctionVariableAssignment(getValue<Token::Identifier>(-2).get());
         else if (sequence(tkn::Operator::Dollar, tkn::Operator::Assign))
             statement = parseFunctionVariableAssignment("$");
-        else if (const auto identifierOffset = parseCompoundAssignment(tkn::Literal::Identifier); identifierOffset.has_value())
+        else if (const auto identifierOffset = isCompoundAssignmentOperator(tkn::Literal::Identifier); identifierOffset.has_value())
             statement = parseFunctionVariableCompoundAssignment(getValue<Token::Identifier>(*identifierOffset).get());
-        else if (parseCompoundAssignment(tkn::Operator::Dollar).has_value())
+        else if (const auto curr = isCompoundAssignmentOperator(); curr.has_value())
+            statement = parseFunctionVariableCompoundAssignment(curr.value());
+        else if (isCompoundAssignmentOperator(tkn::Operator::Dollar).has_value())
             statement = parseFunctionVariableCompoundAssignment("$");
         else if (oneOf(tkn::Keyword::Return, tkn::Keyword::Break, tkn::Keyword::Continue))
             statement = parseFunctionControlFlowStatement();
@@ -999,6 +1001,30 @@ namespace pl::core {
             return nullptr;
 
         return create<ast::ASTNodeLValueAssignment>(lvalue, std::move(rvalue));
+    }
+
+    hlp::safe_unique_ptr<ast::ASTNode> Parser::parseFunctionVariableCompoundAssignment(TokenIter curr) {
+        m_curr = curr;
+        auto lhs = parseRValue();
+        Token::Operator op = getValue<Token::Operator>(0);
+        next();
+        if (op == Token::Operator::BoolLessThan) {
+            op = Token::Operator::LeftShift;
+            next();
+        } else if (op == Token::Operator::BoolGreaterThan) {
+            op = Token::Operator::RightShift;
+            next();
+        }
+        next();
+
+        auto rhs = parseMathematicalExpression();
+        if (rhs == nullptr)
+            return nullptr;
+
+        auto lhsCopy = lhs->clone();
+        rhs = create<ast::ASTNodeMathematicalExpression>(std::move(lhsCopy), std::move(rhs), op);
+
+        return create<ast::ASTNodeRValueAssignment>(std::move(lhs), std::move(rhs));
     }
 
     hlp::safe_unique_ptr<ast::ASTNode> Parser::parseFunctionVariableCompoundAssignment(const std::string &lvalue) {
@@ -1884,12 +1910,14 @@ namespace pl::core {
 
         if (sequence(tkn::Operator::Dollar, tkn::Operator::Assign))
             member = parseFunctionVariableAssignment("$");
-        else if (parseCompoundAssignment(tkn::Operator::Dollar).has_value())
+        else if (isCompoundAssignmentOperator(tkn::Operator::Dollar).has_value())
             member = parseFunctionVariableCompoundAssignment("$");
         else if (sequence(tkn::Literal::Identifier, tkn::Operator::Assign)) {
             member = parseFunctionVariableAssignment(getValue<Token::Identifier>(-2).get());
-        } else if (const auto identifierOffset = parseCompoundAssignment(tkn::Literal::Identifier); identifierOffset.has_value())
+        } else if (const auto identifierOffset = isCompoundAssignmentOperator(tkn::Literal::Identifier); identifierOffset.has_value())
             member = parseFunctionVariableCompoundAssignment(getValue<Token::Identifier>(*identifierOffset).get());
+        else if (const auto curr = isCompoundAssignmentOperator(); curr.has_value())
+            member = parseFunctionVariableCompoundAssignment(curr.value());
         else if (MATCHES((sequence(tkn::Literal::Identifier) || sequence(tkn::Keyword::Parent) || sequence(tkn::Keyword::This)) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1)))))
             member = parseRValueAssignment();
         else if (peek(tkn::Keyword::Const) || peek(tkn::Keyword::BigEndian) || peek(tkn::Keyword::LittleEndian) || peek(tkn::ValueType::Any) || peek(tkn::Literal::Identifier)) {
@@ -2160,8 +2188,10 @@ namespace pl::core {
             if (identifier != nullptr)
                 identifier->setType(Token::Identifier::IdentifierType::LocalVariable);
             member = parseFunctionVariableAssignment(variableName);
-        } else if (const auto identifierOffset = parseCompoundAssignment(tkn::Literal::Identifier); identifierOffset.has_value())
+        } else if (const auto identifierOffset = isCompoundAssignmentOperator(tkn::Literal::Identifier); identifierOffset.has_value())
             member = parseFunctionVariableCompoundAssignment(getValue<Token::Identifier>(*identifierOffset).get());
+        else if (const auto curr = isCompoundAssignmentOperator(); curr.has_value())
+            member = parseFunctionVariableCompoundAssignment(curr.value());
         else if (MATCHES(optional(tkn::Keyword::Unsigned) && sequence(tkn::Literal::Identifier, tkn::Operator::Colon))) {
             auto fieldName = getValue<Token::Identifier>(-2).get();
             auto identifier = std::get_if<Token::Identifier>(&((m_curr[-2]).value));
@@ -2643,8 +2673,10 @@ namespace pl::core {
             statement = parseFunctionVariableAssignment(getValue<Token::Identifier>(-2).get());
         else if (sequence(tkn::Operator::Dollar, tkn::Operator::Assign))
             statement = parseFunctionVariableAssignment("$");
-        else if (const auto identifierOffset = parseCompoundAssignment(tkn::Literal::Identifier); identifierOffset.has_value())
+        else if (const auto identifierOffset = isCompoundAssignmentOperator(tkn::Literal::Identifier); identifierOffset.has_value())
             statement = parseFunctionVariableCompoundAssignment(getValue<Token::Identifier>(*identifierOffset).get());
+        else if (const auto curr = isCompoundAssignmentOperator(); curr.has_value())
+            statement = parseFunctionVariableCompoundAssignment(curr.value());
         else if (MATCHES(sequence(tkn::Keyword::Using, tkn::Literal::Identifier)))
             statement = parseUsingDeclaration();
         else if (sequence(tkn::Keyword::Import))
@@ -2704,20 +2736,49 @@ namespace pl::core {
         return hlp::moveToVector(std::move(statement));
     }
 
-    std::optional<i32> Parser::parseCompoundAssignment(const Token &token) {
+    std::optional<i32> Parser::isCompoundAssignmentOperator(const Token &token) {
+        auto save = m_curr;
+
+        if (sequence(token)) {
+            if (auto offset = isCompoundAssignmentOperator(-1); offset.has_value())
+                return offset;
+        }
+
+        m_curr = save;
+        return std::nullopt;
+    }
+
+    std::optional<i32> Parser::isCompoundAssignmentOperator(i32 offset) {
         const static std::array SingleTokens = { tkn::Operator::Plus, tkn::Operator::Minus, tkn::Operator::Star, tkn::Operator::Slash, tkn::Operator::Percent, tkn::Operator::BitOr, tkn::Operator::BitAnd, tkn::Operator::BitXor };
         const static std::array DoubleTokens = { tkn::Operator::BoolLessThan, tkn::Operator::BoolGreaterThan };
 
-        for (auto &singleToken : SingleTokens) {
-            if (sequence(token, singleToken, tkn::Operator::Assign))
-                return -3;
+        for (auto &token : SingleTokens) {
+            if (sequence(token, tkn::Operator::Assign))
+                return -2 + offset;
         }
 
-        for (auto &doubleTokens : DoubleTokens) {
-            if (sequence(token, doubleTokens, doubleTokens, tkn::Operator::Assign))
-                return -4;
+        for (auto &token : DoubleTokens) {
+            if (sequence(token, token, tkn::Operator::Assign))
+                return -3 + offset;
         }
 
+        return std::nullopt;
+    }
+
+    std::optional<Parser::TokenIter>  Parser::isCompoundAssignmentOperator() {
+        auto save = this->m_curr;
+
+        if (MATCHES(sequence(tkn::Literal::Identifier) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1))))) {
+            auto result = m_curr;
+            auto lhs = parseRValue();
+            if (lhs == nullptr) {
+                m_curr = save;
+                return std::nullopt;
+            }
+            if (isCompoundAssignmentOperator(-1).has_value())
+                return result;
+        }
+        m_curr = save;
         return std::nullopt;
     }
 

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -197,11 +197,17 @@ namespace pl::core {
             path.emplace_back("null");
 
         if (MATCHES(sequence(tkn::Separator::LeftBracket) && !peek(tkn::Separator::LeftBracket))) {
-            path.emplace_back(std::move(parseMathematicalExpression().unwrap()));
+            auto expression = parseMathematicalExpression();
+            if (expression == nullptr) {
+                return nullptr;
+            }
+
             if (!sequence(tkn::Separator::RightBracket)) {
                 error("Expected ']' at end of array indexing, got {}.", getFormattedToken(0));
                 return nullptr;
             }
+
+            path.emplace_back(std::move(expression.unwrap()));
         }
 
         if (sequence(tkn::Separator::Dot)) {
@@ -216,6 +222,8 @@ namespace pl::core {
 
     hlp::safe_unique_ptr<ast::ASTNode> Parser::parseRValueAssignment() {
         auto lhs = parseRValue();
+        if (lhs == nullptr)
+            return nullptr;
 
         if (!sequence(tkn::Operator::Assign)) {
             errorHere("Expected value after '=' in variable assignment, got {}.", getFormattedToken(0));
@@ -2769,13 +2777,15 @@ namespace pl::core {
         return std::nullopt;
     }
 
-    std::optional<Parser::TokenIter>  Parser::isCompoundAssignmentOperator(AllowKeywords allowKeywords) {
+    std::optional<Parser::TokenIter> Parser::isCompoundAssignmentOperator(AllowKeywords allowKeywords) {
         auto save = this->m_curr;
+        auto saveErrors = getErrors();
         bool allowParent = ((u32)allowKeywords & (u32)AllowKeywords::Parent) != 0;
         bool allowThis   = ((u32)allowKeywords & (u32)AllowKeywords::This) != 0;
         if (MATCHES((sequence(tkn::Literal::Identifier) || (allowParent && sequence(tkn::Keyword::Parent)) || (allowThis && sequence(tkn::Keyword::This))) && (peek(tkn::Separator::Dot) || (peek(tkn::Separator::LeftBracket, 0) && !peek(tkn::Separator::LeftBracket, 1))))) {
             auto result = m_curr;
             auto lhs = parseRValue();
+            setErrors(saveErrors);
             if (lhs == nullptr) {
                 m_curr = save;
                 return std::nullopt;


### PR DESCRIPTION
Even though the assignment operator is now supported for rvalued variables compound assignment still resulted on parser errors. This PR aims at adding full support of all compound assignments to rvalued variables. The previous implementation of assignment for rvalues was left intact and a new set of functions were added to integrate rvalues with the existing lvalues compound assignment support.
Checks for null pointers and null expressions were also added to the parser implementation. errorCollector was also modified so its state gets reset alongside the parser in case a predicate function fails to parse.