### PR TITLE
fix: `#pragma once` skipping over the next immediate pragma

### DIFF
--- a/lib/source/pl/pattern_language.cpp
+++ b/lib/source/pl/pattern_language.cpp
@@ -353,7 +353,7 @@ namespace pl {
         const api::Source plSource(code, source);
         const auto result = m_internals.lexer->lex(&plSource);
         if (result.isOk()) {
-            const auto tokens = result.unwrap();
+            const auto& tokens = result.unwrap();
             for (auto it = tokens.begin(); it != tokens.end(); ++it) {
                 if (it->type == core::Token::Type::Directive && std::get<core::Token::Directive>(it->value) == core::Token::Directive::Pragma) {
                     ++it;
@@ -363,12 +363,20 @@ namespace pl {
                         if (string != nullptr) {
                             auto pragmaKey = *string;
                             ++it;
-                            if (it != tokens.end() && it->type == core::Token::Type::String) {
+
+                            if (it == tokens.end()) {
+                                break;
+                            }
+
+                            if (it->type == core::Token::Type::String) {
                                 literal = std::get<core::Token::Literal>(it->value);
                                 string = std::get_if<std::string>(&literal);
                                 if (string != nullptr) {
                                     pragmaValues.emplace(pragmaKey, *string);
                                 }
+                            } else {
+                                // rewind, so pragmas without argument (i.e. "once") don't skip over the next pragma.
+                                --it;
                             }
                         }
                     }

--- a/tests/include/test_patterns/test_pattern_pragmas_pr249.hpp
+++ b/tests/include/test_patterns/test_pattern_pragmas_pr249.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "test_pattern.hpp"
+#include <pl/pattern_language.hpp>
+
+namespace pl::test {
+
+    class TestPatternPragmasIssue249 : public TestPattern {
+    public:
+        TestPatternPragmasIssue249(core::Evaluator *evaluator) : TestPattern(evaluator, "PragmasIssue249") {
+        }
+        ~TestPatternPragmasIssue249() override = default;
+
+        void setup() override {
+            // All pragmas should be processed the same way, but we test multiple ones to be sure
+            m_runtime->addPragma("once", [](PatternLanguage&, const std::string &value) {
+                return true;
+            });
+            m_runtime->addPragma("author", [](PatternLanguage&, const std::string &value) {
+                return value == "authorValue";
+            });
+            m_runtime->addPragma("description", [](PatternLanguage&, const std::string &value) {
+                return value == "descValue";
+            });
+            m_runtime->addPragma("somePragma", [](PatternLanguage&, const std::string &value) {
+                return value == "someValue";
+            });
+            // Also test a pragma which isn't defined in the code, ans whose callback should not be called
+            m_runtime->addPragma("unknownPragma", [](PatternLanguage&, const std::string &value) {
+                return false;
+            });
+        };
+
+        [[nodiscard]] std::string getSourceCode() const override {
+            return R"test(
+                #pragma once
+                #pragma author authorValue
+                #pragma description descValue
+                #pragma somePragma someValue
+
+                u8 test = 0;
+            )test";
+        }
+
+    };
+
+}

--- a/tests/source/tests.cpp
+++ b/tests/source/tests.cpp
@@ -24,6 +24,7 @@
 #include "test_patterns/test_pattern_include.hpp"
 #include "test_patterns/test_pattern_import.hpp"
 #include "test_patterns/test_pattern_pragmas.hpp"
+#include "test_patterns/test_pattern_pragmas_pr249.hpp"
 #include "test_patterns/test_pattern_pragmas_fail.hpp"
 #include "test_patterns/test_pattern_format.hpp"
 #include "test_patterns/test_pattern_rvalues_assignment_in_struct.hpp"
@@ -67,6 +68,7 @@ std::array Tests = {
     TEST(Attributes),
     TEST(StructInheritance),
     TEST(Pragmas),
+    TEST(PragmasIssue249),
     TEST(PragmasFail),
     TEST(Format),
     TEST(RValuesAssignmentInStruct),


### PR DESCRIPTION
```hexpat
#pragma once
#pragma author Nyaaa~!
#pragma description :3
```

would skip over the second #pragma due to the second `it->type` being a Directive and not a String, which would make the subsequent iteration increment it again and compare a String to a Directive