### PR TITLE
fix: prevent forEachEntrySorted crash when sorted entries are stale

### DIFF
--- a/lib/include/pl/patterns/pattern_bitfield.hpp
+++ b/lib/include/pl/patterns/pattern_bitfield.hpp
@@ -383,6 +383,8 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] std::vector<std::shared_ptr<Pattern>> getSortedEntries() override {
+            if (this->m_sortedEntries.empty())
+                return this->getEntries();
             return this->m_sortedEntries;
         }
 
@@ -417,6 +419,7 @@ namespace pl::ptrn {
 
         void setEntries(const std::vector<std::shared_ptr<Pattern>> &entries) override {
             this->m_entries = entries;
+            this->m_sortedEntries.clear();
 
             for (auto &entry : this->m_entries) {
                 if (!entry->hasOverriddenColor())
@@ -644,6 +647,7 @@ namespace pl::ptrn {
             if (!this->m_fields.empty())
                 this->setBaseColor(this->m_fields.front()->getColor());
 
+            this->m_sortedFields.clear();
             for (const auto &field : this->m_fields) {
                 field->setParent(this->reference());
                 this->m_sortedFields.push_back(field);
@@ -754,11 +758,14 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] std::vector<std::shared_ptr<Pattern>> getSortedEntries() override {
+            if (this->m_sortedFields.empty())
+                return this->getEntries();
             return this->m_sortedFields;
         }
 
         void setEntries(const std::vector<std::shared_ptr<Pattern>> &entries) override {
             this->m_fields = entries;
+            this->m_sortedFields.clear();
         }
 
         void setOffset(u64 offset) override {
@@ -778,6 +785,7 @@ namespace pl::ptrn {
             if (this->isSealed())
                 return;
 
+            end = std::min<u64>(end, patterns.size());
             for (auto i = start; i < end; i++) {
                 auto &pattern = patterns[i];
                 if (this->hasAttribute("export") || !pattern->isPatternLocal() || pattern->hasAttribute("export"))

--- a/lib/include/pl/patterns/pattern_struct.hpp
+++ b/lib/include/pl/patterns/pattern_struct.hpp
@@ -37,6 +37,8 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] std::vector<std::shared_ptr<Pattern>> getSortedEntries() override {
+            if (this->m_sortedMembers.empty())
+                return this->getEntries();
             return this->m_sortedMembers;
         }
 
@@ -49,6 +51,7 @@ namespace pl::ptrn {
 
         void setEntries(const std::vector<std::shared_ptr<Pattern>> &entries) override {
             this->m_members.clear();
+            this->m_sortedMembers.clear();
 
             for (const auto &member : entries) {
                 addEntry(member);

--- a/lib/include/pl/patterns/pattern_union.hpp
+++ b/lib/include/pl/patterns/pattern_union.hpp
@@ -37,6 +37,8 @@ namespace pl::ptrn {
         }
 
         [[nodiscard]] std::vector<std::shared_ptr<Pattern>> getSortedEntries() override {
+            if (this->m_sortedMembers.empty())
+                return this->getEntries();
             return this->m_sortedMembers;
         }
 
@@ -48,6 +50,7 @@ namespace pl::ptrn {
 
         void setEntries(const std::vector<std::shared_ptr<Pattern>> &entries) override {
             this->m_members.clear();
+            this->m_sortedMembers.clear();
 
             for (const auto &member : entries) {
                 addEntry(member);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(AVAILABLE_TESTS
         Dollar
         InVariableDefault
         InVariableOverride
+        SetEntriesSortedConsistency
 )
 
 

--- a/tests/include/test_patterns/test_pattern_set_entries_sorted_consistency.hpp
+++ b/tests/include/test_patterns/test_pattern_set_entries_sorted_consistency.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "test_pattern.hpp"
+
+#include <pl/patterns/pattern_struct.hpp>
+#include <pl/patterns/pattern_union.hpp>
+#include <pl/patterns/pattern_bitfield.hpp>
+#include <pl/patterns/pattern_unsigned.hpp>
+
+namespace pl::test {
+
+    // Test that forEachEntrySorted works correctly after setEntries is called
+    // without a preceding sort(). This tests the fix for the bug where
+    // setFields() populates m_sortedFields, but a subsequent setEntries()
+    // overwrites m_fields without updating m_sortedFields, leaving it stale.
+    //
+    // The crash scenario (template bitfield):
+    //   1. ASTNodeBitfield::createPatterns() calls setFields() -> m_fields=2, m_sortedFields=2
+    //   2. ASTNodeTypeDecl::createPatterns() calls setEntries(scope) ->
+    //      m_fields=3 (original 2 + template param), m_sortedFields still 2 (stale!)
+    //   3. forEachEntryImpl: i < end (=3) indexing into patterns (size 2) -> crash
+    class TestPatternSetEntriesSortedConsistency : public TestPattern {
+    public:
+        TestPatternSetEntriesSortedConsistency(core::Evaluator *evaluator) : TestPattern(evaluator, "SetEntriesSortedConsistency") {
+        }
+        ~TestPatternSetEntriesSortedConsistency() override = default;
+
+        [[nodiscard]] std::string getSourceCode() const override {
+            return R"(
+                bitfield TemplateBitfield<auto N> {
+                    unsigned a : 2;
+                    unsigned b : 3;
+                };
+
+                TemplateBitfield<4> bf @ 0;
+            )";
+        }
+
+        [[nodiscard]] bool runChecks(const std::vector<std::shared_ptr<ptrn::Pattern>> &patterns) const override {
+            for (const auto &pattern : patterns) {
+                auto iterable = dynamic_cast<ptrn::IIterable *>(pattern.get());
+                if (iterable == nullptr)
+                    continue;
+
+                size_t entryCount = iterable->getEntryCount();
+                if (entryCount == 0)
+                    continue;
+
+                // forEachEntrySorted and forEachEntry must produce the same
+                // number of non-local entries. Before the fix, forEachEntrySorted
+                // would crash (stale sorted entries) or return fewer entries.
+                size_t sortedCount = 0;
+                iterable->forEachEntrySorted(0, entryCount,
+                    [&](u64, const auto &) { sortedCount++; });
+
+                size_t unsortedCount = 0;
+                iterable->forEachEntry(0, entryCount,
+                    [&](u64, const auto &) { unsortedCount++; });
+
+                if (sortedCount != unsortedCount)
+                    return false;
+            }
+
+            return true;
+        }
+    };
+
+}

--- a/tests/source/tests.cpp
+++ b/tests/source/tests.cpp
@@ -38,6 +38,7 @@
 #include "test_patterns/test_pattern_error_semantics.hpp"
 #include "test_patterns/test_pattern_dollar.hpp"
 #include "test_patterns/test_pattern_in_variable_defaults.hpp"
+#include "test_patterns/test_pattern_set_entries_sorted_consistency.hpp"
 
 static pl::core::Evaluator s_evaluator;
 
@@ -100,4 +101,5 @@ std::array Tests = {
     TEST(Dollar),
     TEST(InVariableDefault),
     TEST(InVariableOverride),
+    TEST(SetEntriesSortedConsistency),
 };


### PR DESCRIPTION
setFields() fills m_sortedFields, but setEntries() overwrites m_fields without touching m_sortedFields. If both get called on the same pattern, sorted goes stale and forEachEntryImpl reads past the end of the sorted vector.

Happens with template bitfields:
  1. ASTNodeBitfield::createPatterns() calls setFields() -> both m_fields and m_sortedFields get populated
  2. ASTNodeTypeDecl::createPatterns() calls setEntries(scope) to add template parameter patterns -> m_fields grows but m_sortedFields is not updated
  3. forEachEntryImpl loops i < getEntryCount() using the stale sorted vector -> heap-buffer-overflow

Fix: setEntries() clears the sorted cache so getSortedEntries() falls back to getEntries(). Also hardened PatternBitfield:
- setFields() clears m_sortedFields before populating (prevents duplicates if called more than once)
- forEachEntryImpl() clamps end to patterns.size(), like the other pattern types already do

Applied to PatternBitfield, PatternBitfieldArray, PatternStruct, and PatternUnion.

I have a rather large pattern that crashes without ASan. The sample below only crashes with ASan since the OOB read lands in valid heap memory.

Sample pattern (ASan required):

    bitfield TemplateBitfield<auto N> {
        unsigned a : 2;
        unsigned b : 3;
    };
    TemplateBitfield<4> bf @ 0;

Test case added: SetEntriesSortedConsistency