### PR TITLE
feat: support using decl types for in/out

### DIFF
--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -2429,22 +2429,50 @@ namespace pl::core {
 
         if (inVariable || outVariable) {
             bool invalidType = false;
-            if (const auto builtinType = dynamic_cast<ast::ASTNodeBuiltinType*>(type->getType().get()); builtinType != nullptr) {
-                if (const auto valueType = builtinType->getType(); !Token::isInteger(valueType)
-                                                                   && !Token::isFloatingPoint(valueType)
-                                                                   && valueType != Token::ValueType::Boolean
-                                                                   && valueType != Token::ValueType::Character
-                                                                   && valueType != Token::ValueType::String)
+            auto visitingType = type;
+            auto declNestLimit = 128; // some high value so infinite recursion breaks
+            while (!invalidType && visitingType && declNestLimit-- > 0) {
+                auto checkType = visitingType->getType();
+
+                if (checkType == nullptr) {
                     invalidType = true;
-            } else if (const auto typeDecl = dynamic_cast<ast::ASTNodeTypeDecl*>(type->getType().get()); typeDecl != nullptr) {
-                if (const auto enumDecl = dynamic_cast<ast::ASTNodeEnum*>(typeDecl->getType().get()); enumDecl == nullptr) {
-                    invalidType = true;
+                    break;
                 }
-            } else {
+
+                if (const auto typeDecl = std::dynamic_pointer_cast<ast::ASTNodeTypeDecl>(checkType); typeDecl != nullptr) {
+                    checkType = typeDecl->getType();
+                }
+
+                if (const auto usingDecl = std::dynamic_pointer_cast<ast::ASTNodeTypeApplication>(checkType); usingDecl != nullptr) {
+                    [[unlikely]] if (usingDecl == visitingType) {
+                        // realistically should never happen but you never know
+                        invalidType = true;
+                        break;
+                    }
+
+                    visitingType = usingDecl;
+                    continue;
+                }
+
+                if (const auto enumDecl = dynamic_cast<ast::ASTNodeEnum *>(checkType.get()); enumDecl != nullptr) {
+                    break;
+                }
+
+                if (const auto builtinType = dynamic_cast<ast::ASTNodeBuiltinType *>(checkType.get()); builtinType != nullptr) {
+                    const auto valueType = builtinType->getType();
+                    invalidType = !Token::isInteger(valueType)
+                                  && !Token::isFloatingPoint(valueType)
+                                  && valueType != Token::ValueType::Boolean
+                                  && valueType != Token::ValueType::Character
+                                  && valueType != Token::ValueType::String;
+                    break;
+                }
+
                 invalidType = true;
+                break;
             }
 
-            if (invalidType) {
+            if (invalidType || visitingType == nullptr || declNestLimit <= 0) {
                 errorDesc("Invalid in/out parameter type.", "Allowed types are: 'char', 'bool', 'str', floating point types, integral types, or enums.");
                 return nullptr;
             }

--- a/lib/source/pl/core/parser.cpp
+++ b/lib/source/pl/core/parser.cpp
@@ -2430,7 +2430,7 @@ namespace pl::core {
         if (inVariable || outVariable) {
             bool invalidType = false;
             auto visitingType = type;
-            auto declNestLimit = 128; // some high value so infinite recursion breaks
+            i32 declNestLimit = 32; // default evaluation depth
             while (!invalidType && visitingType && declNestLimit-- > 0) {
                 auto checkType = visitingType->getType();
 
@@ -2444,8 +2444,8 @@ namespace pl::core {
                 }
 
                 if (const auto usingDecl = std::dynamic_pointer_cast<ast::ASTNodeTypeApplication>(checkType); usingDecl != nullptr) {
-                    [[unlikely]] if (usingDecl == visitingType) {
-                        // realistically should never happen but you never know
+                    if (usingDecl == visitingType) [[unlikely]] {
+                        // bad case of forward declarations ending up referencing itself
                         invalidType = true;
                         break;
                     }


### PR DESCRIPTION
Brought up here: https://github.com/WerWolv/ImHex/pull/2890#discussion_r3971959254

But `using` decls don't work at all even for builtin types. This fixes that.